### PR TITLE
All interior pointers must be enabled for finalized allocation.

### DIFF
--- a/fnlz_mlc.c
+++ b/fnlz_mlc.c
@@ -49,6 +49,10 @@ static GC_bool done_init = FALSE;
 
 GC_API void GC_CALL GC_init_finalized_malloc(void)
 {
+    if (!GC_get_all_interior_pointers())
+        ABORT("GC_set_all_interior_pointers(1) is required for finalized "
+              "object allocation.");
+
     DCL_LOCK_STATE;
 
     GC_init();  /* In case it's not already done.       */

--- a/include/gc_disclaim.h
+++ b/include/gc_disclaim.h
@@ -22,7 +22,8 @@
 
 /* Prepare the object kind used by GC_finalized_malloc.  Call it from   */
 /* your initialization code or, at least, at some point before using    */
-/* finalized allocations.  The function is thread-safe.                 */
+/* finalized allocations.  The function is thread-safe.  All interior   */
+/* pointers must be enabled (GC_set_all_interior_pointers(1)).          */
 GC_API void GC_CALL GC_init_finalized_malloc(void);
 
 /* Type of a disclaim call-back, always stored along with closure data  */

--- a/tests/disclaim_bench.c
+++ b/tests/disclaim_bench.c
@@ -80,6 +80,7 @@ int main(int argc, char **argv)
     int model, model_min, model_max;
     testobj_t *keep_arr;
 
+    GC_set_all_interior_pointers(1);
     GC_INIT();
     GC_init_finalized_malloc();
 

--- a/tests/disclaim_test.c
+++ b/tests/disclaim_test.c
@@ -140,6 +140,7 @@ int main(void)
     int i;
 #endif
 
+    GC_set_all_interior_pointers(1);
     GC_INIT();
     GC_init_finalized_malloc();
 


### PR DESCRIPTION
- include/gc_disclaim.h: Add note about all-interior-pointers requirement.
- fnlz_mlc.c (GC_init_finalized_malloc): Abort with a useful message if all
  interior pointers are not enabled.
- tests/disclaim_bench.c, tests/disclaim_test.c: Enable all interior
  pointers for tests.
