### PR TITLE
Check for automake / aclocal 1.11 as well.

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -5,7 +5,7 @@ set -e
 # These version are ok, pre-1.7 is not.  Post 1.7 may produce a lot of
 # warnings for unrelated projects, so prefer 1.7 for now.
 am_version=
-for v in 1.10 1.9 1.8 1.7; do
+for v in 1.11 1.10 1.9 1.8 1.7; do
     if type -p &>/dev/null automake-$v; then
 	am_version="-$v"
 	break


### PR DESCRIPTION
We had someone trying to build Boehm that only had automake 1.11 installed (on Mac OS X via MacPorts).  This fixed the build for them (since the native versions of autotools don't currently work for Boehm).
