### PR TITLE
Overflow fixes

### DIFF
--- a/malloc.c
+++ b/malloc.c
@@ -169,6 +169,8 @@ GC_API void * GC_CALL GC_generic_malloc(size_t lb, int k)
         GC_bool init;
         lg = ROUNDED_UP_GRANULES(lb);
         lb_rounded = GRANULES_TO_BYTES(lg);
+        if (lb_rounded < lb)
+            return((*GC_get_oom_fn())(lb));
         n_blocks = OBJ_SZ_TO_BLOCKS(lb_rounded);
         init = GC_obj_kinds[k].ok_init;
         LOCK();

--- a/mallocx.c
+++ b/mallocx.c
@@ -182,6 +182,8 @@ GC_INNER void * GC_generic_malloc_ignore_off_page(size_t lb, int k)
         return(GC_generic_malloc((word)lb, k));
     lg = ROUNDED_UP_GRANULES(lb);
     lb_rounded = GRANULES_TO_BYTES(lg);
+    if (lb_rounded < lb)
+        return((*GC_get_oom_fn())(lb));
     n_blocks = OBJ_SZ_TO_BLOCKS(lb_rounded);
     init = GC_obj_kinds[k].ok_init;
     if (EXPECT(GC_have_errors, FALSE))


### PR DESCRIPTION
Hi,

This fixes two integer overflows in GC_generic_malloc() and calloc(), respectively, which could lead to buffer overflows.
