### PR TITLE
Loop in GC_alloc_large

### DIFF
--- a/alloc.c
+++ b/alloc.c
@@ -1078,6 +1078,16 @@ GC_INNER void GC_add_to_heap(struct hblk *p, size_t bytes)
     phdr -> hb_flags = 0;
     GC_freehblk(p);
     GC_heapsize += bytes;
+
+    /* Normally the caller calculates a new GC_collect_at_heapsize,
+     * but this is also called directly from alloc_mark_stack, so
+     * adjust here. It will be recalculated when called from
+     * GC_expand_hp_inner.
+     */
+    GC_collect_at_heapsize += bytes;
+    if (GC_collect_at_heapsize < GC_heapsize /* wrapped */)
+       GC_collect_at_heapsize = (word)(-1);
+
     if ((word)p <= (word)GC_least_plausible_heap_addr
         || GC_least_plausible_heap_addr == 0) {
         GC_least_plausible_heap_addr = (void *)((ptr_t)p - sizeof(word));


### PR DESCRIPTION
Hi, I'm debugging a problem building Guile (that uses bdwgc) with parallel mark. I'm currently working on an issue of the mark stack growing very large in the parallel case, but for the moment this change is needed to stop allocation looping when that happens.

Basically, I bump `GC_collect_at_heapsize` in `GC_add_to_heap`. In the normal case it is recalculated straight after. But in the case where it's called directly from `alloc_mark_stack`, it isn't. If the mark stack gets very large, this can cause `GC_should_collect` to always return true, and `GC_alloc_large` to get stuck in a loop calling `GC_collect_or_expand`.

It's not very satisfactory, but the caller (`alloc_mark_stack`) does not have the ability to recalculate `GC_collect_at_heapsize`, nor probably should it do so as it's outside of alloc.c.
