### PR TITLE
Fix crash in GC_scratch_alloc under low-memory conditions

### DIFF
--- a/headers.c
+++ b/headers.c
@@ -131,10 +131,8 @@ GC_INNER ptr_t GC_scratch_alloc(size_t bytes)
         if (bytes_to_get <= bytes) {
           /* Undo the damage, and get memory directly */
             bytes_to_get = bytes;
-#           ifdef USE_MMAP
-                bytes_to_get += GC_page_size - 1;
-                bytes_to_get &= ~(GC_page_size - 1);
-#           endif
+            bytes_to_get += GC_page_size - 1;
+            bytes_to_get &= ~(GC_page_size - 1);
             result = (ptr_t)GET_MEM(bytes_to_get);
             GC_add_to_our_memory(result, bytes_to_get);
             scratch_free_ptr -= bytes;
@@ -147,10 +145,8 @@ GC_INNER ptr_t GC_scratch_alloc(size_t bytes)
             WARN("Out of memory - trying to allocate less\n", 0);
             scratch_free_ptr -= bytes;
             bytes_to_get = bytes;
-#           ifdef USE_MMAP
-                bytes_to_get += GC_page_size - 1;
-                bytes_to_get &= ~(GC_page_size - 1);
-#           endif
+            bytes_to_get += GC_page_size - 1;
+            bytes_to_get &= ~(GC_page_size - 1);
             result = (ptr_t)GET_MEM(bytes_to_get);
             GC_add_to_our_memory(result, bytes_to_get);
             return result;


### PR DESCRIPTION
- headers.c (GC_scratch_alloc): Always round bytes_to_get up to a
  multiple of the page size, even if USE_MMAP is not defined.  This is
  necessary because GC_unix_get_mem, which is one of the possible
  GET_MEM implementations, may use mmap even if USE_MMAP isn't defined.
  See os_dep.c for a definition of GC_unix_get_mem which tries sbrk
  first, but then falls back to mmap.  Calling GC_unix_mmap_get_mem will
  abort if the allocation is not a multiple of the page size.

Here's an example stack trace of the error without this patch:

GC Warning: Out of memory - trying to allocate less
Bad GET_MEM arg

Program received signal SIGABRT, Aborted.
0x00007ffff6fd83a9 in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
56  ../nptl/sysdeps/unix/sysv/linux/raise.c: No such file or directory.
(gdb) bt
#0  0x00007ffff6fd83a9 in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
#1  0x00007ffff6fdb4c8 in __GI_abort () at abort.c:89
#2  0x00007ffff6d50009 in GC_unix_mmap_get_mem (bytes=bytes@entry=336) at os_dep.c:2065
#3  0x00007ffff6d500e0 in GC_unix_get_mem (bytes=bytes@entry=336) at os_dep.c:2152
#4  0x00007ffff6d483ef in GC_scratch_alloc (bytes=336, bytes@entry=328) at headers.c:154
#5  0x00007ffff6d4863f in alloc_hdr () at headers.c:173
#6  GC_install_header (h=h@entry=0x7ffff2413000) at headers.c:266
#7  0x00007ffff6d41ae0 in GC_get_first_part (h=h@entry=0x7ffff2412000, hhdr=hhdr@entry=0x7ffff1dbcea0, bytes=bytes@entry=4096, index=index@entry=60)

```
at allchblk.c:500
```
#8  0x00007ffff6d41e0a in GC_allochblk_nth (sz=sz@entry=16, kind=kind@entry=1, flags=flags@entry=0, n=n@entry=60, may_split=may_split@entry=1)

```
at allchblk.c:783
```
#9  0x00007ffff6d421c6 in GC_allochblk (sz=sz@entry=16, kind=kind@entry=1, flags=flags@entry=0) at allchblk.c:624
#10 0x00007ffff6d49d85 in GC_generic_malloc_many (lb=16, k=1, result=0x68ff00) at mallocx.c:404
