### PR TITLE
Use ARM_UNIFIED_THREAD_STATE in the call to thread_get_state() on iOS7 64-bit  and up and iOS8 32-bit and up

### DIFF
--- a/darwin_stop_world.c
+++ b/darwin_stop_world.c
@@ -15,10 +15,6 @@
  * modified is included with the above copyright notice.
  */
 
-#include <sys/sysctl.h>
-#include <mach/machine.h>
-#include <CoreFoundation/CoreFoundation.h>
-
 #include "private/pthread_support.h"
 
 /* This probably needs more porting work to ppc64. */
@@ -27,6 +23,7 @@
 
 #include <sys/sysctl.h>
 #include <mach/machine.h>
+#include <CoreFoundation/CoreFoundation.h>
 
 /* From "Inside Mac OS X - Mach-O Runtime Architecture" published by Apple
    Page 49:


### PR DESCRIPTION
Sorry for the noise. I've now tested that other PR on iOS 8 and it fails. It looks like the way to go from iOS 7 and up is to use ARM_UNIFIED_THREAD_STATE. This patch checks the iOS version the app is running on and uses ARM_UNIFIED_THREAD_STATE only if on iOS 7 and up. One weird thing though is that when running on iOS 7 32-bit ARM_UNIFIED_THREAD_STATE doesn't work as expected while the old code does. So this patch will only use ARM_UNIFIED_THREAD_STATE in iOS 7 64-bit and on iOS 8 and up.

Patch tested on iOS 7 32-bit and 64-bit devices and on iOS 8 32-bit device.
