### PR TITLE
Improve __alloc_size__ detection

### DIFF
--- a/include/gc_config_macros.h
+++ b/include/gc_config_macros.h
@@ -242,14 +242,22 @@
 #ifndef GC_ATTR_ALLOC_SIZE
   /* 'alloc_size' attribute improves __builtin_object_size correctness. */
   /* Only single-argument form of 'alloc_size' attribute is used.       */
-# if defined(__GNUC__) && (__GNUC__ > 4 \
-        || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3 && !defined(__ICC)) \
-        || __clang_major__ > 3 \
-        || (__clang_major__ == 3 && __clang_minor__ >= 2 \
-            && (__clang_minor__ != 5 || __clang_patchlevel__ != 0)))
-#   define GC_ATTR_ALLOC_SIZE(argnum) __attribute__((__alloc_size__(argnum)))
-# else
-#   define GC_ATTR_ALLOC_SIZE(argnum)
+# ifdef __clang__
+#   if __has_attribute(__alloc_size__)
+#     define GC_ATTR_ALLOC_SIZE(argnum) __attribute__((__alloc_size__(argnum)))
+#   else
+#     define GC_ATTR_ALLOC_SIZE(argnum)
+#   endif
+# endif
+
+# ifndef GC_ATTR_ALLOC_SIZE
+#   if (defined(__GNUC__) \
+      && (__GNUC__ > 4 \
+        || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3 && !defined(__ICC))))
+#     define GC_ATTR_ALLOC_SIZE(argnum) __attribute__((__alloc_size__(argnum)))
+#   else
+#     define GC_ATTR_ALLOC_SIZE(argnum)
+#   endif
 # endif
 #endif
 


### PR DESCRIPTION
Since `__clang_major__`/`__clang_minor__` etc. are vendor dependent values,
we cannot implement the feature detection based on it.
For example, Apple clang versioning is different from the FreeBSD clang.
(At this time, Apple clang version is `"6.0 (clang-600.0.51)"` and
`__clang_major__` is 6)

Instead of this, we can use the clang feature detection macro,
`__has_attribute`.
