### PR TITLE
Freshen MIT licensing terms of gc_allocator.h

### DIFF
--- a/include/gc/gc_allocator.h
+++ b/include/gc/gc_allocator.h
@@ -1,25 +1,15 @@
 /*
- * Copyright (c) 1996-1997
- * Silicon Graphics Computer Systems, Inc.
+ * Copyright (c) 1996-1997 Silicon Graphics Computer Systems, Inc.
+ * Copyright (c) 2002 Hewlett-Packard Company
  *
- * Permission to use, copy, modify, distribute and sell this software
- * and its documentation for any purpose is hereby granted without fee,
- * provided that the above copyright notice appear in all copies and
- * that both that copyright notice and this permission notice appear
- * in supporting documentation.  Silicon Graphics makes no
- * representations about the suitability of this software for any
- * purpose.  It is provided "as is" without express or implied warranty.
+ * THIS MATERIAL IS PROVIDED AS IS, WITH ABSOLUTELY NO WARRANTY EXPRESSED
+ * OR IMPLIED.  ANY USE IS AT YOUR OWN RISK.
  *
- * Copyright (c) 2002
- * Hewlett-Packard Company
- *
- * Permission to use, copy, modify, distribute and sell this software
- * and its documentation for any purpose is hereby granted without fee,
- * provided that the above copyright notice appear in all copies and
- * that both that copyright notice and this permission notice appear
- * in supporting documentation.  Hewlett-Packard Company makes no
- * representations about the suitability of this software for any
- * purpose.  It is provided "as is" without express or implied warranty.
+ * Permission is hereby granted to use or copy this program
+ * for any purpose, provided the above notices are retained on all copies.
+ * Permission to modify the code and to distribute modified code is granted,
+ * provided the above notices are retained, and a notice that the code was
+ * modified is included with the above copyright notice.
  */
 
 /*


### PR DESCRIPTION
See report: https://app.fossa.com/projects/git%2Bgithub.com%2Fbdwgc%2Fbdwgc/refs/branch/master/32fd37b5b0ca373d592c0602740a79afbd150599/issues/licensing/10251364?revisionScanId=87109507

Change licensing terms from MIT old-style to new MIT (as specified in other `.h` files).

Now all MIT-licensed source files are covered with same (new) version of MIT license.