### PR TITLE
Eliminate 'strerror is not thread-safe' code defect in tests

### DIFF
--- a/tests/disclaim.c
+++ b/tests/disclaim.c
@@ -279,8 +279,9 @@ main(void)
   printf("Threaded disclaim test.\n");
   for (i = 0; i < NTHREADS; ++i) {
     int err = pthread_create(&th[i], NULL, test, NULL);
+
     if (err != 0) {
-      fprintf(stderr, "Thread #%d creation failed: %s\n", i, strerror(err));
+      fprintf(stderr, "Thread #%d creation failed, errno= %d\n", i, err);
       if (i > 1 && EAGAIN == err)
         break;
       exit(1);
@@ -292,8 +293,9 @@ main(void)
 #if NTHREADS > 0
   for (i = 0; i < n; ++i) {
     int err = pthread_join(th[i], NULL);
+
     if (err != 0) {
-      fprintf(stderr, "Thread #%d join failed: %s\n", i, strerror(err));
+      fprintf(stderr, "Thread #%d join failed, errno= %d\n", i, err);
       exit(69);
     }
   }

--- a/tests/initfromthread.c
+++ b/tests/initfromthread.c
@@ -31,7 +31,6 @@
 
 #ifdef GC_PTHREADS
 #  include <pthread.h>
-#  include <string.h>
 #else
 #  ifndef WIN32_LEAN_AND_MEAN
 #    define WIN32_LEAN_AND_MEAN 1
@@ -107,12 +106,12 @@ main(void)
 #ifdef GC_PTHREADS
   err = pthread_create(&t, NULL, thread, NULL);
   if (err != 0) {
-    fprintf(stderr, "Thread #0 creation failed: %s\n", strerror(err));
+    fprintf(stderr, "Thread #0 creation failed, errno= %d\n", err);
     return 1;
   }
   err = pthread_join(t, NULL);
   if (err != 0) {
-    fprintf(stderr, "Thread #0 join failed: %s\n", strerror(err));
+    fprintf(stderr, "Thread #0 join failed, errno= %d\n", err);
     return 1;
   }
 #else

--- a/tests/subthreadcreate.c
+++ b/tests/subthreadcreate.c
@@ -24,7 +24,6 @@
 #  ifdef GC_PTHREADS
 #    include <errno.h> /*< for `EAGAIN` */
 #    include <pthread.h>
-#    include <string.h>
 #  else
 #    ifndef WIN32_LEAN_AND_MEAN
 #      define WIN32_LEAN_AND_MEAN 1
@@ -77,15 +76,16 @@ entry(LPVOID arg)
 
     err = pthread_create(&th, NULL, entry, (void *)(GC_uintptr_t)my_depth);
     if (err != 0) {
-      fprintf(stderr, "Thread #%d creation failed from other thread: %s\n",
-              thread_num, strerror(err));
+      fprintf(stderr,
+              "Thread #%d creation failed from other thread, errno= %d\n",
+              thread_num, err);
       if (err != EAGAIN)
         exit(2);
     } else {
       err = pthread_detach(th);
       if (err != 0) {
-        fprintf(stderr, "Thread #%d detach failed: %s\n", thread_num,
-                strerror(err));
+        fprintf(stderr, "Thread #%d detach failed, errno= %d\n", thread_num,
+                err);
         exit(2);
       }
     }
@@ -126,8 +126,8 @@ main(void)
 #    ifdef GC_PTHREADS
     err = pthread_create(&th[i], NULL, entry, 0);
     if (err != 0) {
-      fprintf(stderr, "Thread #%d creation failed: %s\n", th_nums[i],
-              strerror(err));
+      fprintf(stderr, "Thread #%d creation failed, errno= %d\n", th_nums[i],
+              err);
       if (i > 0 && EAGAIN == err)
         break;
       exit(1);
@@ -152,8 +152,7 @@ main(void)
 
     err = pthread_join(th[i], &res);
     if (err != 0) {
-      fprintf(stderr, "Thread #%d join failed: %s\n", th_nums[i],
-              strerror(err));
+      fprintf(stderr, "Thread #%d join failed, errno= %d\n", th_nums[i], err);
       exit(1);
     }
 #    else

--- a/tests/threadkey.c
+++ b/tests/threadkey.c
@@ -37,7 +37,6 @@ main(void)
 
 #  include <errno.h> /*< for `EAGAIN` */
 #  include <pthread.h>
-#  include <string.h>
 
 pthread_key_t key;
 
@@ -113,7 +112,7 @@ main(void)
     int err = GC_pthread_create(&t, NULL, entry, NULL);
 
     if (err != 0) {
-      fprintf(stderr, "Thread #%d creation failed: %s\n", i, strerror(err));
+      fprintf(stderr, "Thread #%d creation failed, errno= %d\n", i, err);
       if (i > 0 && EAGAIN == err)
         break;
       exit(2);
@@ -122,13 +121,13 @@ main(void)
     if ((i & 1) != 0) {
       err = GC_pthread_join(t, &res);
       if (err != 0) {
-        fprintf(stderr, "Thread #%d join failed: %s\n", i, strerror(err));
+        fprintf(stderr, "Thread #%d join failed, errno= %d\n", i, err);
         exit(2);
       }
     } else {
       err = GC_pthread_detach(t);
       if (err != 0) {
-        fprintf(stderr, "Thread #%d detach failed: %s\n", i, strerror(err));
+        fprintf(stderr, "Thread #%d detach failed, errno= %d\n", i, err);
         exit(2);
       }
     }

--- a/tests/threadleak.c
+++ b/tests/threadleak.c
@@ -13,7 +13,6 @@
 #ifdef GC_PTHREADS
 #  include <errno.h> /*< for `EAGAIN` */
 #  include <pthread.h>
-#  include <string.h>
 #else
 #  ifndef WIN32_LEAN_AND_MEAN
 #    define WIN32_LEAN_AND_MEAN 1
@@ -90,7 +89,7 @@ main(void)
     int err = pthread_create(t + i, 0, test, 0);
 
     if (err != 0) {
-      fprintf(stderr, "Thread #%d creation failed: %s\n", i, strerror(err));
+      fprintf(stderr, "Thread #%d creation failed, errno= %d\n", i, err);
       if (i > 1 && EAGAIN == err)
         break;
       exit(2);

--- a/tests/weakmap.c
+++ b/tests/weakmap.c
@@ -159,7 +159,7 @@ weakmap_trylock(struct weakmap *wm, unsigned h)
   int err = pthread_mutex_trylock(&wm->mutex[h % WEAKMAP_MUTEX_COUNT]);
 
   if (err != 0 && err != EBUSY) {
-    fprintf(stderr, "pthread_mutex_trylock: %s\n", strerror(err));
+    fprintf(stderr, "pthread_mutex_trylock, errno= %d\n", err);
     exit(69);
   }
   return err;
@@ -502,7 +502,7 @@ main(void)
     int err = pthread_create(&th[i], NULL, test, NULL);
 
     if (err != 0) {
-      fprintf(stderr, "Thread #%d creation failed: %s\n", i, strerror(err));
+      fprintf(stderr, "Thread #%d creation failed, errno= %d\n", i, err);
       if (i > 1 && EAGAIN == err)
         break;
       exit(1);
@@ -516,7 +516,7 @@ main(void)
     int err = pthread_join(th[i], NULL);
 
     if (err != 0) {
-      fprintf(stderr, "Thread #%d join failed: %s\n", i, strerror(err));
+      fprintf(stderr, "Thread #%d join failed, errno= %d\n", i, err);
       exit(69);
     }
   }


### PR DESCRIPTION
Note: `strerror_r()` is thread-safe but it is not available on some platforms, so we just print the error code (on error) instead of the error message.