### PR TITLE
Fix reading async proc maps when GC is single-threaded but process is not

### DIFF
--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -2566,6 +2566,16 @@ extern char __global_base, __heap_base;
 #  define THREADS
 #endif
 
+/*
+ * If the client app is known not to create threads (even indirectly in
+ * the used libraries) and the collector is not multi-threaded, then the
+ * collector could be built with `SINGLE_THREADED_PROCESS` macro defined.
+ * But in practice the macro should never be defined.
+ */
+#if defined(THREADS) && defined(SINGLE_THREADED_PROCESS)
+#  undef SINGLE_THREADED_PROCESS
+#endif
+
 #if defined(__CHERI_PURE_CAPABILITY__)
 #  define CHERI_PURECAP
 #endif


### PR DESCRIPTION


Even if the collector is built w/o thread support, the client might use the threads those are not manipulating GC pointers (e.g. in some 3rd-party library), thus we should handle the case of an asynchronous change of `/proc/self/maps` file content (as if the collector is multi-threaded).

Additionally, `SINGLE_THREADED_PROCESS` macro is introduced if the client could guarantee the process is single-threaded (and, thus, asynchronous change of `/proc/self/maps` is not possible). But, practically, this macro should not be used.
