### PR TITLE
build.zig: Switch to unmanaged containers

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -130,17 +130,17 @@ pub fn build(b: *std.Build) void {
         "Install header and pkg-config metadata files") orelse true;
     // TODO: support `with_libatomic_ops`, `without_libatomic_ops`
 
-    var source_files = std.ArrayList([]const u8).init(b.allocator);
-    defer source_files.deinit();
-    var flags = std.ArrayList([]const u8).init(b.allocator);
-    defer flags.deinit();
+    var source_files: std.ArrayListUnmanaged([]const u8) = .empty;
+    defer source_files.deinit(b.allocator);
+    var flags: std.ArrayListUnmanaged([]const u8) = .empty;
+    defer flags.deinit(b.allocator);
 
     // Always enabled.
-    flags.append("-D ALL_INTERIOR_POINTERS") catch unreachable;
-    flags.append("-D NO_EXECUTE_PERMISSION") catch unreachable;
+    flags.append(b.allocator, "-D ALL_INTERIOR_POINTERS") catch unreachable;
+    flags.append(b.allocator, "-D NO_EXECUTE_PERMISSION") catch unreachable;
 
     // Output all warnings.
-    flags.appendSlice(&.{
+    flags.appendSlice(b.allocator, &.{
         "-Wall",
         "-Wextra",
         "-Wpedantic",
@@ -148,10 +148,10 @@ pub fn build(b: *std.Build) void {
 
     // Disable MS `crt` security warnings reported e.g. for `getenv`, `strcpy`.
     if (t.abi == .msvc) {
-        flags.append("-D _CRT_SECURE_NO_DEPRECATE") catch unreachable;
+        flags.append(b.allocator, "-D _CRT_SECURE_NO_DEPRECATE") catch unreachable;
     }
 
-    source_files.appendSlice(&.{
+    source_files.appendSlice(b.allocator, &.{
         "allchblk.c",
         "alloc.c",
         "blacklst.c",
@@ -173,53 +173,53 @@ pub fn build(b: *std.Build) void {
     }) catch unreachable;
 
     if (enable_threads) {
-        flags.append("-D GC_THREADS") catch unreachable;
+        flags.append(b.allocator, "-D GC_THREADS") catch unreachable;
         if (enable_parallel_mark) {
-            flags.append("-D PARALLEL_MARK") catch unreachable;
+            flags.append(b.allocator, "-D PARALLEL_MARK") catch unreachable;
         }
         if (t.os.tag != .windows) { // assume `pthreads`
             // TODO: support cygwin when supported by zig
             // Zig comes with clang which supports GCC atomic intrinsics.
-            flags.append("-D GC_BUILTIN_ATOMIC") catch unreachable;
+            flags.append(b.allocator, "-D GC_BUILTIN_ATOMIC") catch unreachable;
             // TODO: define and use `THREADDLLIBS_LIST`
-            source_files.appendSlice(&.{
+            source_files.appendSlice(b.allocator, &.{
                 "gc_dlopen.c",
                 "pthread_start.c",
                 "pthread_support.c",
             }) catch unreachable;
             if (t.os.tag.isDarwin()) {
-                source_files.append("darwin_stop_world.c") catch unreachable;
+                source_files.append(b.allocator, "darwin_stop_world.c") catch unreachable;
             } else {
-                source_files.append("pthread_stop_world.c") catch unreachable;
+                source_files.append(b.allocator, "pthread_stop_world.c") catch unreachable;
             }
             // Common defines for POSIX platforms.
-            flags.append("-D _REENTRANT") catch unreachable;
+            flags.append(b.allocator, "-D _REENTRANT") catch unreachable;
             // TODO: some targets might need `_PTHREADS` defined too.
             if (enable_thread_local_alloc) {
-                flags.append("-D THREAD_LOCAL_ALLOC") catch unreachable;
-                source_files.appendSlice(&.{
+                flags.append(b.allocator, "-D THREAD_LOCAL_ALLOC") catch unreachable;
+                source_files.appendSlice(b.allocator, &.{
                     "specific.c",
                     "thread_local_alloc.c",
                 }) catch unreachable;
             }
             // Message for clients: Explicit `GC_INIT` call may be required.
             if (enable_handle_fork and !disable_handle_fork) {
-                flags.append("-D HANDLE_FORK") catch unreachable;
+                flags.append(b.allocator, "-D HANDLE_FORK") catch unreachable;
             }
             if (enable_sigrt_signals) {
-                flags.append("-D GC_USESIGRT_SIGNALS") catch unreachable;
+                flags.append(b.allocator, "-D GC_USESIGRT_SIGNALS") catch unreachable;
             }
         } else {
             // Assume the GCC atomic intrinsics are supported.
-            flags.append("-D GC_BUILTIN_ATOMIC") catch unreachable;
+            flags.append(b.allocator, "-D GC_BUILTIN_ATOMIC") catch unreachable;
             if (enable_thread_local_alloc
                     and (enable_parallel_mark or !build_shared_libs)) {
                 // Imply `THREAD_LOCAL_ALLOC` unless `GC_DLL`.
-                flags.append("-D THREAD_LOCAL_ALLOC") catch unreachable;
-                source_files.append("thread_local_alloc.c") catch unreachable;
+                flags.append(b.allocator, "-D THREAD_LOCAL_ALLOC") catch unreachable;
+                source_files.append(b.allocator, "thread_local_alloc.c") catch unreachable;
             }
-            flags.append("-D EMPTY_GETENV_RESULTS") catch unreachable;
-            source_files.appendSlice(&.{
+            flags.append(b.allocator, "-D EMPTY_GETENV_RESULTS") catch unreachable;
+            source_files.appendSlice(b.allocator, &.{
                 // Add `pthread_start.c` file just in case client defines
                 // `GC_WIN32_PTHREADS` macro.
                 "pthread_start.c",
@@ -232,157 +232,157 @@ pub fn build(b: *std.Build) void {
     // TODO: define/use `NEED_LIB_RT`
 
     if (disable_handle_fork) {
-        flags.append("-D NO_HANDLE_FORK") catch unreachable;
+        flags.append(b.allocator, "-D NO_HANDLE_FORK") catch unreachable;
     }
 
     if (enable_gcj_support) {
-        flags.append("-D GC_GCJ_SUPPORT") catch unreachable;
+        flags.append(b.allocator, "-D GC_GCJ_SUPPORT") catch unreachable;
         // TODO: do not define `GC_ENABLE_SUSPEND_THREAD` on kFreeBSD
         // if `enable_thread_local_alloc` (a workaround for some bug).
-        flags.append("-D GC_ENABLE_SUSPEND_THREAD") catch unreachable;
-        source_files.append("gcj_mlc.c") catch unreachable;
+        flags.append(b.allocator, "-D GC_ENABLE_SUSPEND_THREAD") catch unreachable;
+        source_files.append(b.allocator, "gcj_mlc.c") catch unreachable;
     }
 
     if (enable_disclaim) {
-        flags.append("-D ENABLE_DISCLAIM") catch unreachable;
-        source_files.append("fnlz_mlc.c") catch unreachable;
+        flags.append(b.allocator, "-D ENABLE_DISCLAIM") catch unreachable;
+        source_files.append(b.allocator, "fnlz_mlc.c") catch unreachable;
     }
 
     if (enable_dynamic_pointer_mask) {
-        flags.append("-D DYNAMIC_POINTER_MASK") catch unreachable;
+        flags.append(b.allocator, "-D DYNAMIC_POINTER_MASK") catch unreachable;
     }
 
     if (enable_java_finalization) {
-        flags.append("-D JAVA_FINALIZATION") catch unreachable;
+        flags.append(b.allocator, "-D JAVA_FINALIZATION") catch unreachable;
     }
 
     if (enable_atomic_uncollectable) {
-        flags.append("-D GC_ATOMIC_UNCOLLECTABLE") catch unreachable;
+        flags.append(b.allocator, "-D GC_ATOMIC_UNCOLLECTABLE") catch unreachable;
     }
 
     if (enable_valgrind_tracking) {
-        flags.append("-D VALGRIND_TRACKING") catch unreachable;
+        flags.append(b.allocator, "-D VALGRIND_TRACKING") catch unreachable;
     }
 
     if (enable_gc_debug) {
-        flags.append("-D DBG_HDRS_ALL") catch unreachable;
-        flags.append("-D KEEP_BACK_PTRS") catch unreachable;
+        flags.append(b.allocator, "-D DBG_HDRS_ALL") catch unreachable;
+        flags.append(b.allocator, "-D KEEP_BACK_PTRS") catch unreachable;
         if (t.os.tag == .linux) {
-            flags.append("-D MAKE_BACK_GRAPH") catch unreachable;
+            flags.append(b.allocator, "-D MAKE_BACK_GRAPH") catch unreachable;
             // TODO: do not define `SAVE_CALL_COUNT` for e2k
-            flags.append("-D SAVE_CALL_COUNT=8") catch unreachable;
-            source_files.append("backgraph.c") catch unreachable;
+            flags.append(b.allocator, "-D SAVE_CALL_COUNT=8") catch unreachable;
+            source_files.append(b.allocator, "backgraph.c") catch unreachable;
         }
     }
 
     if (disable_gc_debug) {
-        flags.append("-D NO_DEBUGGING") catch unreachable;
+        flags.append(b.allocator, "-D NO_DEBUGGING") catch unreachable;
     }
     if (optimize != .Debug) {
-        flags.append("-D NDEBUG") catch unreachable;
+        flags.append(b.allocator, "-D NDEBUG") catch unreachable;
     }
 
     if (enable_redirect_malloc) {
         if (enable_gc_debug) {
-            flags.append("-D REDIRECT_MALLOC=GC_debug_malloc_replacement")
+            flags.append(b.allocator, "-D REDIRECT_MALLOC=GC_debug_malloc_replacement")
                 catch unreachable;
-            flags.append("-D REDIRECT_REALLOC=GC_debug_realloc_replacement")
+            flags.append(b.allocator, "-D REDIRECT_REALLOC=GC_debug_realloc_replacement")
                 catch unreachable;
-            flags.append("-D REDIRECT_FREE=GC_debug_free") catch unreachable;
+            flags.append(b.allocator, "-D REDIRECT_FREE=GC_debug_free") catch unreachable;
         } else {
-            flags.append("-D REDIRECT_MALLOC=GC_malloc") catch unreachable;
+            flags.append(b.allocator, "-D REDIRECT_MALLOC=GC_malloc") catch unreachable;
         }
         if (t.os.tag == .windows) {
-            flags.append("-D REDIRECT_MALLOC_IN_HEADER") catch unreachable;
+            flags.append(b.allocator, "-D REDIRECT_MALLOC_IN_HEADER") catch unreachable;
         } else {
-            flags.append("-D GC_USE_DLOPEN_WRAP") catch unreachable;
+            flags.append(b.allocator, "-D GC_USE_DLOPEN_WRAP") catch unreachable;
         }
     }
 
     if (enable_mmap or enable_munmap) {
-        flags.append("-D USE_MMAP") catch unreachable;
+        flags.append(b.allocator, "-D USE_MMAP") catch unreachable;
     }
 
     if (enable_munmap) {
-        flags.append("-D USE_MUNMAP") catch unreachable;
+        flags.append(b.allocator, "-D USE_MUNMAP") catch unreachable;
     }
 
     if (!enable_dynamic_loading) {
-        flags.append("-D IGNORE_DDYNAMIC_LOADING") catch unreachable;
+        flags.append(b.allocator, "-D IGNORE_DDYNAMIC_LOADING") catch unreachable;
     }
 
     if (!enable_register_main_static_data) {
-        flags.append("-D GC_DONT_REGISTER_MAIN_STATIC_DATA") catch unreachable;
+        flags.append(b.allocator, "-D GC_DONT_REGISTER_MAIN_STATIC_DATA") catch unreachable;
     }
 
     if (enable_large_config) {
-        flags.append("-D LARGE_CONFIG") catch unreachable;
+        flags.append(b.allocator, "-D LARGE_CONFIG") catch unreachable;
     }
 
     if (enable_gc_assertions) {
-        flags.append("-D GC_ASSERTIONS") catch unreachable;
+        flags.append(b.allocator, "-D GC_ASSERTIONS") catch unreachable;
     }
 
     if (!enable_threads_discovery) {
-        flags.append("-D GC_NO_THREADS_DISCOVERY") catch unreachable;
+        flags.append(b.allocator, "-D GC_NO_THREADS_DISCOVERY") catch unreachable;
     }
 
     if (enable_rwlock) {
-        flags.append("-D USE_RWLOCK") catch unreachable;
+        flags.append(b.allocator, "-D USE_RWLOCK") catch unreachable;
     }
 
     if (enable_checksums) {
         if (enable_munmap or enable_threads) {
             @panic("CHECKSUMS not compatible with USE_MUNMAP or threads");
         }
-        flags.append("-D CHECKSUMS") catch unreachable;
-        source_files.append("checksums.c") catch unreachable;
+        flags.append(b.allocator, "-D CHECKSUMS") catch unreachable;
+        source_files.append(b.allocator, "checksums.c") catch unreachable;
     }
 
     if (enable_werror) {
-        flags.append("-Werror") catch unreachable;
+        flags.append(b.allocator, "-Werror") catch unreachable;
     }
 
     if (enable_single_obj_compilation
             or (build_shared_libs and !disable_single_obj_compilation)) {
-        source_files.clearAndFree();
-        source_files.append("extra/gc.c") catch unreachable;
+        source_files.clearAndFree(b.allocator);
+        source_files.append(b.allocator, "extra/gc.c") catch unreachable;
         if (enable_threads and !t.os.tag.isDarwin() and t.os.tag != .windows) {
-            flags.append("-D GC_PTHREAD_START_STANDALONE") catch unreachable;
-            source_files.append("pthread_start.c") catch unreachable;
+            flags.append(b.allocator, "-D GC_PTHREAD_START_STANDALONE") catch unreachable;
+            source_files.append(b.allocator, "pthread_start.c") catch unreachable;
         }
     }
 
     // Add implementation of `backtrace` and `backtrace_symbols`.
     if (t.abi == .msvc) {
-        source_files.append("extra/msvc_dbg.c") catch unreachable;
+        source_files.append(b.allocator, "extra/msvc_dbg.c") catch unreachable;
     }
 
     // TODO: declare that the libraries do not refer to external symbols
     // of `build_shared_libs`.
 
     // `zig cc` supports this flag.
-    flags.appendSlice(&.{
+    flags.appendSlice(b.allocator, &.{
         // TODO: `-Wno-unused-command-line-argument`
         // Prevent "__builtin_return_address with nonzero argument is unsafe".
         "-Wno-frame-address",
     }) catch unreachable;
 
     if (build_shared_libs) {
-        flags.append("-D GC_DLL") catch unreachable;
+        flags.append(b.allocator, "-D GC_DLL") catch unreachable;
         if (t.abi == .msvc) {
             // TODO: depend on `user32.lib` file instead
-            flags.append("-D DONT_USE_USER32_DLL") catch unreachable;
+            flags.append(b.allocator, "-D DONT_USE_USER32_DLL") catch unreachable;
         } else {
             // `zig cc` supports these flags.
-            flags.append("-D GC_VISIBILITY_HIDDEN_SET") catch unreachable;
-            flags.append("-fvisibility=hidden") catch unreachable;
+            flags.append(b.allocator, "-D GC_VISIBILITY_HIDDEN_SET") catch unreachable;
+            flags.append(b.allocator, "-fvisibility=hidden") catch unreachable;
         }
     } else {
-        flags.append("-D GC_NOT_DLL") catch unreachable;
+        flags.append(b.allocator, "-D GC_NOT_DLL") catch unreachable;
         if (t.os.tag == .windows) {
             // Do not require the clients to link with `user32` system library.
-            flags.append("-D DONT_USE_USER32_DLL") catch unreachable;
+            flags.append(b.allocator, "-D DONT_USE_USER32_DLL") catch unreachable;
         }
     }
 
@@ -391,39 +391,39 @@ pub fn build(b: *std.Build) void {
     // hard-code enable this.
     // `-U GC_MISSING_EXECINFO_H`
     // `-U GC_NO_SIGSETJMP`
-    flags.append("-D HAVE_SYS_TYPES_H") catch unreachable;
+    flags.append(b.allocator, "-D HAVE_SYS_TYPES_H") catch unreachable;
 
     if (t.abi == .msvc) {
         // To workaround "extension used" error reported
         // for `__try`/`__finally`.
-        flags.append("-D NO_SEH_AVAILABLE") catch unreachable;
+        flags.append(b.allocator, "-D NO_SEH_AVAILABLE") catch unreachable;
     } else {
-        flags.append("-D HAVE_UNISTD_H") catch unreachable;
+        flags.append(b.allocator, "-D HAVE_UNISTD_H") catch unreachable;
     }
 
     const have_getcontext = !t.abi.isMusl() and t.os.tag != .windows;
     if (!have_getcontext) {
-        flags.append("-D NO_GETCONTEXT") catch unreachable;
+        flags.append(b.allocator, "-D NO_GETCONTEXT") catch unreachable;
     }
 
     if (!t.os.tag.isDarwin() and t.os.tag != .windows) {
         // `dl_iterate_phdr` exists (as a strong symbol).
-        flags.append("-D HAVE_DL_ITERATE_PHDR") catch unreachable;
+        flags.append(b.allocator, "-D HAVE_DL_ITERATE_PHDR") catch unreachable;
         if (enable_threads) {
             // `pthread_sigmask` and `sigset_t` are available and needed.
-            flags.append("-D HAVE_PTHREAD_SIGMASK") catch unreachable;
+            flags.append(b.allocator, "-D HAVE_PTHREAD_SIGMASK") catch unreachable;
         }
     }
 
     // Build with `GC_wcsdup` support (`wcslen` is available).
-    flags.append("-D GC_REQUIRE_WCSDUP") catch unreachable;
+    flags.append(b.allocator, "-D GC_REQUIRE_WCSDUP") catch unreachable;
 
     // `pthread_setname_np`, if available, may have 1, 2 or 3 arguments.
     if (t.os.tag.isDarwin()) {
-        flags.append("-D HAVE_PTHREAD_SETNAME_NP_WITHOUT_TID")
+        flags.append(b.allocator, "-D HAVE_PTHREAD_SETNAME_NP_WITHOUT_TID")
                 catch unreachable;
     } else if (t.os.tag == .linux) {
-        flags.append("-D HAVE_PTHREAD_SETNAME_NP_WITH_TID") catch unreachable;
+        flags.append(b.allocator, "-D HAVE_PTHREAD_SETNAME_NP_WITH_TID") catch unreachable;
     } else {
         // TODO: support `HAVE_PTHREAD_SETNAME_NP_WITH_TID_AND_ARG`
         // and `HAVE_PTHREAD_SET_NAME_NP` targets.
@@ -431,27 +431,27 @@ pub fn build(b: *std.Build) void {
 
     if (t.os.tag != .windows) {
         // Define to use `dladdr` function (used for debugging).
-        flags.append("-D HAVE_DLADDR") catch unreachable;
+        flags.append(b.allocator, "-D HAVE_DLADDR") catch unreachable;
     }
 
     // TODO: as of zig 0.14, exception.h and getsect.h are not provided
     // by zig itself for Darwin target.
     if (t.os.tag.isDarwin() and !target.query.isNative()) {
-        flags.append("-D MISSING_MACH_O_GETSECT_H") catch unreachable;
-        flags.append("-D NO_MPROTECT_VDB") catch unreachable;
+        flags.append(b.allocator, "-D MISSING_MACH_O_GETSECT_H") catch unreachable;
+        flags.append(b.allocator, "-D NO_MPROTECT_VDB") catch unreachable;
     }
 
     if (enable_cplusplus and enable_werror) {
         if (build_shared_libs and t.os.tag == .windows or t.abi == .msvc) {
             // Avoid "replacement operator new[] cannot be declared inline"
             // warnings.
-            flags.append("-Wno-inline-new-delete") catch unreachable;
+            flags.append(b.allocator, "-Wno-inline-new-delete") catch unreachable;
         }
         if (t.abi == .msvc) {
             // TODO: as of zig 0.14,
             // "argument unused during compilation: -nostdinc++" warning is
             // reported if using MS compiler.
-            flags.append("-Wno-unused-command-line-argument")
+            flags.append(b.allocator, "-Wno-unused-command-line-argument")
                 catch unreachable;
         }
     }
@@ -461,7 +461,7 @@ pub fn build(b: *std.Build) void {
         // Split it up on a space and append each part to flags separately.
         var tokenizer = std.mem.tokenizeScalar(u8, cflags_extra, ' ');
         while (tokenizer.next()) |token| {
-            flags.append(token) catch unreachable;
+            flags.append(b.allocator, token) catch unreachable;
         }
     }
 


### PR DESCRIPTION
This is in preparation for the upcoming Zig 0.15 release. Managed containers (storing an allocator) will go away, unmanaged ones (passing an allocator to functions that need to allocate) are becoming the default. What is called `std.ArrayListUnmanaged` up until Zig 0.14 has been renamed to `std.ArrayList` in 0.15 (https://github.com/ziglang/zig/pull/24801) with the old name still available as a deprecated alias.

This change is backwards compatible as both types of containers have existed for a long time.