### PR TITLE
Workaround some gcc-13 analyzer warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -235,7 +235,6 @@ jobs:
     - MAKEFILE_TARGETS="check cord/de"
     - MAKE_NPROC=8
   - compiler: gcc
-    dist: jammy
     env:
     - CFLAGS_EXTRA="-O3 -march=native -fanalyzer"
     - CONF_OPTIONS="--enable-cplusplus"
@@ -461,7 +460,6 @@ jobs:
     - CFLAGS_EXTRA="-D LINT2 -D NO_VDB_FOR_STATIC_ROOTS -D TEST_REUSE_SIG_SUSPEND"
     - GCTEST_WITH_MPROTECT_VDB=true
   - compiler: gcc
-    dist: jammy
     env:
     - CONF_OPTIONS="--enable-large-config --enable-redirect-malloc --disable-threads"
     - CFLAGS_EXTRA="-O3 -fanalyzer"
@@ -490,7 +488,6 @@ jobs:
     - GCTEST_WITH_MPROTECT_VDB=true
     - NO_CLONE_LIBATOMIC_OPS=true
   - compiler: gcc
-    dist: jammy
     env:
     - CONF_OPTIONS="--disable-static --disable-threads --enable-cplusplus"
     - CFLAGS_EXTRA="-O3 -march=native -fanalyzer -D DONT_PROTECT_PTRFREE -D GC_PREFER_MPROTECT_VDB"

--- a/gc_badalc.cc
+++ b/gc_badalc.cc
@@ -35,7 +35,7 @@
 #  define GC_ALLOCATOR_THROW_OR_ABORT() throw std::bad_alloc()
 #endif
 
-GC_API void GC_CALL
+GC_API GC_OOM_ABORT_THROW_ATTRIBUTE void GC_CALL
 GC_throw_bad_alloc()
 {
   GC_ALLOCATOR_THROW_OR_ABORT();

--- a/include/gc/gc.h
+++ b/include/gc/gc.h
@@ -1854,8 +1854,18 @@ typedef void(GC_CALLBACK *GC_abort_func)(const char * /* `msg` */);
 GC_API void GC_CALL GC_set_abort_func(GC_abort_func) GC_ATTR_NONNULL(1);
 GC_API GC_abort_func GC_CALL GC_get_abort_func(void);
 
+/*
+ * Clients should define `GC_EXIT_LACKS_NORETURN` macro if the platform
+ * `exit()` does not have a `noreturn` attribute.
+ */
+#ifdef GC_EXIT_LACKS_NORETURN
+#  define GC_OOM_ABORT_THROW_ATTRIBUTE /*< empty */
+#else
+#  define GC_OOM_ABORT_THROW_ATTRIBUTE GC_ATTR_NORETURN
+#endif
+
 /** A portable way to abort the application because of not enough memory. */
-GC_API void GC_CALL GC_abort_on_oom(void);
+GC_API GC_OOM_ABORT_THROW_ATTRIBUTE void GC_CALL GC_abort_on_oom(void);
 
 /*
  * The following is intended to be used by a higher level (e.g.
@@ -2462,7 +2472,7 @@ extern "C" {
 #      ifdef GC_WINDOWS_H_INCLUDED
 #        define DECLSPEC_NORETURN /*< empty */
 #      else
-#        define DECLSPEC_NORETURN __declspec(noreturn)
+#        define DECLSPEC_NORETURN GC_ATTR_NORETURN
 #      endif
 #    endif
 

--- a/include/gc/gc_config_macros.h
+++ b/include/gc/gc_config_macros.h
@@ -373,6 +373,18 @@ typedef long ptrdiff_t;
 #    endif
 #  endif
 
+#  ifndef GC_ATTR_NORETURN
+#    if GC_GNUC_PREREQ(2, 7)
+#      define GC_ATTR_NORETURN __attribute__((__noreturn__))
+#    elif defined(_MSC_VER) && _MSC_VER >= 1310 /*< VS 2003+ */
+#      define GC_ATTR_NORETURN __declspec(noreturn)
+#    elif defined(__NORETURN) /*< used in Solaris */
+#      define GC_ATTR_NORETURN __NORETURN
+#    else
+#      define GC_ATTR_NORETURN /*< empty */
+#    endif
+#  endif
+
 #  if defined(__sgi) && !defined(__GNUC__) && _COMPILER_VERSION >= 720
 #    define GC_ADD_CALLER
 #    define GC_RETURN_ADDR ((GC_return_addr_t)__return_address)
@@ -482,13 +494,7 @@ typedef long ptrdiff_t;
             || defined(GC_SOLARIS_THREADS) || defined(__COSMOPOLITAN__))
 /* Intercept `pthread_exit()` where available and needed. */
 #      define GC_HAVE_PTHREAD_EXIT
-#      if GC_GNUC_PREREQ(2, 7)
-#        define GC_PTHREAD_EXIT_ATTRIBUTE __attribute__((__noreturn__))
-#      elif defined(__NORETURN) /*< used in Solaris */
-#        define GC_PTHREAD_EXIT_ATTRIBUTE __NORETURN
-#      else
-#        define GC_PTHREAD_EXIT_ATTRIBUTE /*< empty */
-#      endif
+#      define GC_PTHREAD_EXIT_ATTRIBUTE GC_ATTR_NORETURN
 #    endif
 
 #    if (!defined(GC_HAVE_PTHREAD_EXIT) || defined(__native_client__)) \

--- a/include/gc/gc_cpp.h
+++ b/include/gc/gc_cpp.h
@@ -232,7 +232,7 @@ Cautions:
 #else
 // The platform `new` header file is not included, so `bad_alloc` cannot
 // be thrown directly.
-GC_API void GC_CALL GC_throw_bad_alloc();
+GC_API GC_OOM_ABORT_THROW_ATTRIBUTE void GC_CALL GC_throw_bad_alloc();
 #  define GC_OP_NEW_OOM_CHECK(obj) \
     if (obj) {                     \
     } else                         \

--- a/misc.c
+++ b/misc.c
@@ -3051,7 +3051,7 @@ GC_get_force_unmap_on_gcollect(void)
   return (int)GC_force_unmap_on_gcollect;
 }
 
-GC_API void GC_CALL
+GC_API GC_OOM_ABORT_THROW_ATTRIBUTE void GC_CALL
 GC_abort_on_oom(void)
 {
   GC_err_printf("Insufficient memory for the allocation\n");

--- a/tests/leak.c
+++ b/tests/leak.c
@@ -46,8 +46,10 @@ main(void)
   }
   _aligned_free(p[0]);
 
-  for (i = 0; i < N_TESTS; ++i) {
-    p[i] = i > 0 ? (char *)malloc(sizeof(int) + i) : strdup("abc");
+  p[0] = strdup("abc");
+  CHECK_OUT_OF_MEMORY(p[0]);
+  for (i = 1; i < N_TESTS; ++i) {
+    p[i] = (char *)malloc(sizeof(int) + i);
     CHECK_OUT_OF_MEMORY(p[i]);
     (void)malloc_usable_size(p[i]);
   }


### PR DESCRIPTION
Workaround "use of unitialized variable" false positives (FPs) reported by gcc-13 `-fanalyzer`:
1. In .cc files
2. In tests/leak.c

Use Ubuntu noble for analyzer builds where no more FPs.