### PR TITLE
Fix reliance on glibc-specific `__data_start` for some Linux platforms

### DIFF
--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -1680,9 +1680,13 @@ extern char *_STACKTOP;
 #  define MACH_TYPE "LOONGARCH"
 #  define CPP_WORDSZ (__SIZEOF_SIZE_T__ * 8)
 #  ifdef LINUX
-#    pragma weak __data_start
+#    ifdef __GLIBC__
+#      pragma weak __data_start
 extern int __data_start[];
-#    define DATASTART ((ptr_t)__data_start)
+#      define DATASTART ((ptr_t)__data_start)
+#    else
+#      define SEARCH_FOR_DATA_START
+#    endif
 #  endif
 #endif /* LOONGARCH */
 
@@ -1702,9 +1706,13 @@ extern int __data_start[];
 #    else
 #      define CPP_WORDSZ 32
 #    endif
-#    pragma weak __data_start
+#    ifdef __GLIBC__
+#      pragma weak __data_start
 extern int __data_start[];
-#    define DATASTART ((ptr_t)__data_start)
+#      define DATASTART ((ptr_t)__data_start)
+#    else
+#      define SEARCH_FOR_DATA_START
+#    endif
 #    ifndef HBLKSIZE
 #      define HBLKSIZE 4096
 #    endif
@@ -1804,8 +1812,12 @@ extern char **environ;
 #    define HBLKSIZE 4096
 #  endif
 #  ifdef LINUX
+#    ifdef __GLIBC__
 extern int __data_start[];
-#    define DATASTART ((ptr_t)__data_start)
+#      define DATASTART ((ptr_t)__data_start)
+#    else
+#      define SEARCH_FOR_DATA_START
+#    endif
 #  endif
 #endif /* NIOS2 */
 
@@ -1816,8 +1828,12 @@ extern int __data_start[];
 #    define HBLKSIZE 4096
 #  endif
 #  ifdef LINUX
+#    ifdef __GLIBC__
 extern int __data_start[];
-#    define DATASTART ((ptr_t)__data_start)
+#      define DATASTART ((ptr_t)__data_start)
+#    else
+#      define SEARCH_FOR_DATA_START
+#    endif
 #  endif
 #endif /* OR1K */
 
@@ -2075,9 +2091,13 @@ extern int _etext[], _end[];
 #    endif
 #  endif
 #  ifdef LINUX
+#    ifdef __GLIBC__
 extern int __data_start[] __attribute__((__weak__));
+#      define DATASTART ((ptr_t)__data_start)
+#    else
+#      define SEARCH_FOR_DATA_START
+#    endif
 extern int _end[] __attribute__((__weak__));
-#    define DATASTART ((ptr_t)__data_start)
 #    define DATAEND ((ptr_t)_end)
 #    define CACHE_LINE_SIZE 256
 #    define GETPAGESIZE() 4096
@@ -2101,8 +2121,12 @@ extern int _end[] __attribute__((__weak__));
 #    if defined(HOST_ANDROID)
 #      define SEARCH_FOR_DATA_START
 #    else
+#      ifdef __GLIBC__
 extern int __data_start[] __attribute__((__weak__));
-#      define DATASTART ((ptr_t)__data_start)
+#        define DATASTART ((ptr_t)__data_start)
+#      else
+#        define SEARCH_FOR_DATA_START
+#      endif
 #    endif
 #  endif
 #  ifdef COSMO
@@ -2444,8 +2468,12 @@ LONG64 durango_get_stack_bottom(void);
 #  define CPP_WORDSZ 32
 #  define CACHE_LINE_SIZE 64
 #  ifdef LINUX
+#    ifdef __GLIBC__
 extern int __data_start[] __attribute__((__weak__));
-#    define DATASTART ((ptr_t)__data_start)
+#      define DATASTART ((ptr_t)__data_start)
+#    else
+#      define SEARCH_FOR_DATA_START
+#    endif
 #  endif
 #endif /* ARC */
 
@@ -2467,8 +2495,12 @@ extern int __data_start[] __attribute__((__weak__));
 #  define PREFETCH(x) __insn_prefetch(x)
 #  define CACHE_LINE_SIZE 64
 #  ifdef LINUX
+#    ifdef __GLIBC__
 extern int __data_start[];
-#    define DATASTART ((ptr_t)__data_start)
+#      define DATASTART ((ptr_t)__data_start)
+#    else
+#      define SEARCH_FOR_DATA_START
+#    endif
 #  endif
 #endif /* TILEPRO */
 
@@ -2481,8 +2513,12 @@ extern int __data_start[];
 #  define PREFETCH(x) __insn_prefetch_l1(x)
 #  define CACHE_LINE_SIZE 64
 #  ifdef LINUX
+#    ifdef __GLIBC__
 extern int __data_start[];
-#    define DATASTART ((ptr_t)__data_start)
+#      define DATASTART ((ptr_t)__data_start)
+#    else
+#      define SEARCH_FOR_DATA_START
+#    endif
 #  endif
 #endif /* TILEGX */
 
@@ -2493,8 +2529,12 @@ extern int __data_start[];
 /* Nothing specific. */
 #  endif
 #  ifdef LINUX
+#    ifdef __GLIBC__
 extern int __data_start[] __attribute__((__weak__));
-#    define DATASTART ((ptr_t)__data_start)
+#      define DATASTART ((ptr_t)__data_start)
+#    else
+#      define SEARCH_FOR_DATA_START
+#    endif
 #  endif
 #  ifdef NETBSD
 /* Nothing specific. */


### PR DESCRIPTION
Setting `DATASTART` based on `__data_start` only works when the `__data_start` symbol is defined somewhere, and this seems to be a glibc-specific feature (i.e. not available on musl libc). To avoid a "Wrong DATASTART/END pair" runtime error[^1] when bdwgc is built for non-glibc Linux platforms, we should fall back to `SEARCH_FOR_DATA_START` if not using glibc.

Affected architectures:
- aarch64
- arc
- loongarch
- mips
- nios2
- or1k
- riscv
- s390
- tilegx
- tilepro

Compiled code remains unaffected when using glibc.

[^1]: Side note: the linker doesn't seem to catch the missing definition at link time due to `__data_start` being declared as a weak symbol.