### PR TITLE
Fix comment for endif in GC_print_callers

### DIFF
--- a/os_dep.c
+++ b/os_dep.c
@@ -5872,7 +5872,7 @@ GC_print_callers(struct callinfo info[NFRAMES])
 #    endif
         name = result_buf;
       } while (0);
-#  endif /* LINUX */
+#  endif
       GC_err_printf("\t\t%s\n", name);
 #  if defined(GC_HAVE_BUILTIN_BACKTRACE) \
       && !defined(GC_BACKTRACE_SYMBOLS_BROKEN) && defined(FUNCPTR_IS_DATAPTR)


### PR DESCRIPTION
Remove wrong (outdated) comment for `endif` belonging to `ifdef CALLINFO_USE_ADDR2LINE`.