### PR TITLE
Don't close thread handles on dllmain process exit

### DIFF
--- a/win32_threads.c
+++ b/win32_threads.c
@@ -1991,7 +1991,6 @@ GC_DllMain(HINSTANCE inst, ULONG reason, LPVOID reserved)
   thread_id_t self_id;
 
   UNUSED_ARG(inst);
-  UNUSED_ARG(reserved);
   /*
    * Note that `GC_use_threads_discovery` should be called by the client
    * application at start-up to activate automatic thread registration
@@ -2044,6 +2043,10 @@ GC_DllMain(HINSTANCE inst, ULONG reason, LPVOID reserved)
     break;
 
   case DLL_PROCESS_DETACH:
+    /* Do nothing on process exit, handles will be closed automatically */
+    if (reserved != NULL)
+      break;
+
     if (GC_win32_dll_threads) {
       int i;
       int my_max = (int)GC_get_max_thread_index();


### PR DESCRIPTION
reserved != NULL indicates that the process is exiting, in which case handles will be closed automatically so we shouldn't do that here.

See: https://devblogs.microsoft.com/oldnewthing/20120105-00/?p=8683

> Don’t worry about freeing memory; it will all go away when the process
> address space is destroyed. Don’t worry about closing handles; handles
> are closed automatically when the process handle table is destroyed.