### PR TITLE
Fix dll loader deaklock

### DIFF
--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -751,19 +751,15 @@ GC_INNER void GC_win32_dll_resume_all_threads(void);
 #  define GC_win32_dll_resume_all_threads() (void)0
 #endif
 
-/* Abandon ship. */
 #ifdef SMALL_CONFIG
 #  define GC_on_abort(msg) (void)0 /*< be silent on abort */
 #else
 GC_API_PRIV GC_abort_func GC_on_abort;
 #endif
+
 #if defined(CPPCHECK)
-#  define ABORT(msg)                     \
-    {                                    \
-      GC_win32_dll_resume_all_threads(); \
-      GC_on_abort(msg);                  \
-      abort();                           \
-    }
+#  define ABORT_ACT() abort()
+#  define ABORT_IS_STMT
 #else
 #  if defined(MSWIN_XBOX1) && !defined(DebugBreak)
 #    define DebugBreak() __debugbreak()
@@ -783,35 +779,37 @@ GC_API_PRIV GC_abort_func GC_on_abort;
  * A more user-friendly abort after showing fatal message.
  * Exit on error without running "at-exit" callbacks.
  */
-#    define ABORT(msg) \
-      (GC_win32_dll_resume_all_threads(), GC_on_abort(msg), _exit(-1))
+#    define ABORT_ACT() _exit(-1)
 #  elif defined(MSWINCE) && defined(NO_DEBUGGING)
-#    define ABORT(msg) (GC_on_abort(msg), ExitProcess(-1))
+#    define ABORT_ACT() ExitProcess(-1)
 #  elif defined(MSWIN32) || defined(MSWINCE)
 #    if defined(_CrtDbgBreak) && defined(_DEBUG) && defined(_MSC_VER)
-#      define ABORT(msg)                          \
-        {                                         \
-          GC_win32_dll_resume_all_threads();      \
-          GC_on_abort(msg);                       \
-          _CrtDbgBreak() /*< `__debugbreak()` */; \
-        }
+#      define ABORT_ACT() _CrtDbgBreak() /*< `__debugbreak()` */
 #    else
-#      define ABORT(msg)                     \
-        {                                    \
-          GC_win32_dll_resume_all_threads(); \
-          GC_on_abort(msg);                  \
-          DebugBreak();                      \
-        }
+#      define ABORT_ACT() DebugBreak()
 /*
  * Note: on a WinCE box, this could be silently ignored (i.e., the program
  * is not aborted); `DebugBreak()` is a statement in some toolchains.
  */
 #    endif
+#    define ABORT_IS_STMT
 #  else /* !MSWIN32 */
-#    define ABORT(msg) \
-      (GC_win32_dll_resume_all_threads(), GC_on_abort(msg), abort())
+#    define ABORT_ACT() abort()
 #  endif
 #endif /* !CPPCHECK */
+
+/* Abandon ship. */
+#ifdef ABORT_IS_STMT
+#  define ABORT(msg)                     \
+    {                                    \
+      GC_win32_dll_resume_all_threads(); \
+      GC_on_abort(msg);                  \
+      ABORT_ACT();                       \
+    }
+#else
+#  define ABORT(msg) \
+    (GC_win32_dll_resume_all_threads(), GC_on_abort(msg), ABORT_ACT())
+#endif
 
 /*
  * For the abort message with 1 .. 3 arguments.  `C_msg` and `C_fmt`

--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -738,6 +738,19 @@ GC_INNER void GC_start_world(void);
 #  define START_WORLD()
 #endif
 
+#if defined(GC_WIN32_THREADS) && !defined(GC_NO_THREADS_DISCOVERY) \
+    && !defined(SMALL_CONFIG) && defined(GC_BUILD)
+/*
+ * Resume all suspended threads, if any.  Called right before `GC_on_abort()`
+ * to avoid a potential deadlock if there is a suspended `DllMain` thread
+ * holding the Windows loader lock.  Otherwise, in particular, `MessageBoxA()`
+ * call is unsafe.
+ */
+GC_INNER void GC_win32_dll_resume_all_threads(void);
+#else
+#  define GC_win32_dll_resume_all_threads() (void)0
+#endif
+
 /* Abandon ship. */
 #ifdef SMALL_CONFIG
 #  define GC_on_abort(msg) (void)0 /*< be silent on abort */
@@ -745,10 +758,11 @@ GC_INNER void GC_start_world(void);
 GC_API_PRIV GC_abort_func GC_on_abort;
 #endif
 #if defined(CPPCHECK)
-#  define ABORT(msg)    \
-    {                   \
-      GC_on_abort(msg); \
-      abort();          \
+#  define ABORT(msg)                     \
+    {                                    \
+      GC_win32_dll_resume_all_threads(); \
+      GC_on_abort(msg);                  \
+      abort();                           \
     }
 #else
 #  if defined(MSWIN_XBOX1) && !defined(DebugBreak)
@@ -769,21 +783,24 @@ GC_API_PRIV GC_abort_func GC_on_abort;
  * A more user-friendly abort after showing fatal message.
  * Exit on error without running "at-exit" callbacks.
  */
-#    define ABORT(msg) (GC_on_abort(msg), _exit(-1))
+#    define ABORT(msg) \
+      (GC_win32_dll_resume_all_threads(), GC_on_abort(msg), _exit(-1))
 #  elif defined(MSWINCE) && defined(NO_DEBUGGING)
 #    define ABORT(msg) (GC_on_abort(msg), ExitProcess(-1))
 #  elif defined(MSWIN32) || defined(MSWINCE)
 #    if defined(_CrtDbgBreak) && defined(_DEBUG) && defined(_MSC_VER)
 #      define ABORT(msg)                          \
         {                                         \
+          GC_win32_dll_resume_all_threads();      \
           GC_on_abort(msg);                       \
           _CrtDbgBreak() /*< `__debugbreak()` */; \
         }
 #    else
-#      define ABORT(msg)    \
-        {                   \
-          GC_on_abort(msg); \
-          DebugBreak();     \
+#      define ABORT(msg)                     \
+        {                                    \
+          GC_win32_dll_resume_all_threads(); \
+          GC_on_abort(msg);                  \
+          DebugBreak();                      \
         }
 /*
  * Note: on a WinCE box, this could be silently ignored (i.e., the program
@@ -791,7 +808,8 @@ GC_API_PRIV GC_abort_func GC_on_abort;
  */
 #    endif
 #  else /* !MSWIN32 */
-#    define ABORT(msg) (GC_on_abort(msg), abort())
+#    define ABORT(msg) \
+      (GC_win32_dll_resume_all_threads(), GC_on_abort(msg), abort())
 #  endif
 #endif /* !CPPCHECK */
 

--- a/tests/gctest.c
+++ b/tests/gctest.c
@@ -2459,12 +2459,12 @@ main(void)
      * e.g. when `malloc` redirection is on.
      */
     GC_clear_exclusion_table();
-#if defined(THREADS) && !defined(GC_NO_THREADS_DISCOVERY)    \
-    && !defined(THREAD_LOCAL_ALLOC)                          \
-    && (defined(DARWIN) && !defined(DARWIN_DONT_PARSE_STACK) \
-        || (defined(GC_WIN32_THREADS) && defined(GC_DLL)     \
+#if defined(THREADS) && !defined(TEST_NO_THREADS_DISCOVERY)              \
+    && !defined(GC_NO_THREADS_DISCOVERY) && !defined(THREAD_LOCAL_ALLOC) \
+    && (defined(DARWIN) && !defined(DARWIN_DONT_PARSE_STACK)             \
+        || (defined(GC_WIN32_THREADS) && defined(GC_DLL)                 \
             && !defined(MSWINCE)))
-    /* Test with implicit thread registration if possible. */
+    /* Test with implicit thread registration. */
     GC_use_threads_discovery();
 #  ifdef DARWIN
     GC_printf("Using Darwin task-threads-based world stop and push\n");

--- a/win32_threads.c
+++ b/win32_threads.c
@@ -53,6 +53,11 @@ static ptr_t copy_ptr_regs(word *regs, const CONTEXT *pcontext);
  * number of threads.
  */
 
+#    ifndef GC_INSIDE_DLL
+#      define GC_DllMain DllMain
+BOOL WINAPI GC_DllMain(HINSTANCE inst, ULONG reason, LPVOID reserved);
+#    endif
+
 /*
  * `GC_DISCOVER_TASK_THREADS` should be used if `DllMain`-based thread
  * registration is required but it is impossible to call
@@ -2035,8 +2040,6 @@ GC_thr_init(void)
 #    ifdef GC_INSIDE_DLL
 /* Export only if needed by client. */
 GC_API
-#    else
-#      define GC_DllMain DllMain
 #    endif
 BOOL WINAPI
 GC_DllMain(HINSTANCE inst, ULONG reason, LPVOID reserved)

--- a/win32_threads.c
+++ b/win32_threads.c
@@ -658,6 +658,33 @@ GC_stop_world(void)
 #  endif
 }
 
+#  if !defined(GC_NO_THREADS_DISCOVERY) && !defined(SMALL_CONFIG)
+GC_ATTR_NOINLINE
+GC_INNER void
+GC_win32_dll_resume_all_threads(void)
+{
+  if (GC_win32_dll_threads) {
+    /*
+     * Note: we do not check `GC_please_stop` here because in an abort
+     * situation (fatal error), the safest approach is to always iterate
+     * through the table resuming all suspended threads, if any.
+     * The overhead is negligible since we are about to abort anyway.
+     */
+    int i, my_max = GC_get_max_thread_index();
+
+    for (i = 0; i <= my_max; i++) {
+      GC_thread p = (GC_thread)(dll_thread_table + i);
+
+      if (UNLIKELY((p->flags & IS_SUSPENDED) != 0)) {
+        (void)ResumeThread(p->handle);
+        /* Ignore errors as we are aborting anyway. */
+        p->flags &= (unsigned char)~IS_SUSPENDED;
+      }
+    }
+  }
+}
+#  endif
+
 GC_INNER void
 GC_start_world(void)
 {


### PR DESCRIPTION
* New macro TEST_NO_THREADS_DISCOVERY to test without use_threads_discovery
* Fix deadlock caused by MessageBox call while DllMain thread is suspended (this closes #886)
* Minimize code duplication in ABORT definition (refactoring) 
* Fix 'GC_DllMain undeclared' compiler error if CPPCHECK defined