### PR TITLE
Fix crash in backtrace() when called from GC_debug_generic_malloc_inner (release 8.2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -324,6 +324,7 @@ jobs:
     - CFLAGS_EXTRA="-m32"
     - NO_CLONE_LIBATOMIC_OPS=true
   - compiler: gcc
+    dist: focal
     env:
     - CONF_OPTIONS="--enable-redirect-malloc --enable-gc-debug --enable-cplusplus --enable-gc-assertions"
   - compiler: clang

--- a/dbg_mlc.c
+++ b/dbg_mlc.c
@@ -619,7 +619,7 @@ STATIC void * GC_debug_generic_malloc(size_t lb, int knd, GC_EXTRA_PARAMS)
         GC_start_debugging_inner();
     }
     result = GC_store_debug_info_inner(base, (word)lb, "INTERNAL", 0);
-    ADD_CALL_CHAIN(base, GC_RETURN_ADDR);
+    ADD_CALL_CHAIN_SAFE(base, GC_RETURN_ADDR);
     return result;
   }
 


### PR DESCRIPTION
fix of commit 963c85ec9
