### PR TITLE
Support targeting Windows on ARM64 with MSVC

### DIFF
--- a/NT_MAKEFILE
+++ b/NT_MAKEFILE
@@ -4,6 +4,7 @@
 # are:
 # - `cpu=AMD64` to target x64;
 # - `cpu=i386` to target x86;
+# - `cpu=ARM64` to target Windows on ARM64;
 # - `enable_static=1` to build it as a static library;
 # - `nodebug=1` to produce the release variant of the library;
 # - `disable_threads=1` to build the library without multi-threading support.
@@ -19,6 +20,8 @@ CPU = $(PROCESSOR_ARCHITECTURE)
 CPU = i386
 !ELSEIF "$(CPU)" == "X64" || "$(CPU)" == "x64" || "$(CPU)" == "amd64"
 CPU = AMD64
+!ELSEIF "$(CPU)" == "arm64" || "$(CPU)" == "AARCH64" || "$(CPU)" == "aarch64"
+CPU = ARM64
 !ENDIF
 
 !IF !DEFINED(NMAKE_WINVER)
@@ -30,6 +33,8 @@ cflags = $(cflags) -c -DCRTAPI1=_cdecl -DCRTAPI2=_cdecl -GS -D_WINNT -W4
 cflags = $(cflags) -D_X86_=1  -DWIN32 -D_WIN32
 !ELSEIF "$(CPU)" == "AMD64"
 cflags = $(cflags) -D_AMD64_=1 -DWIN64 -D_WIN64  -DWIN32 -D_WIN32
+!ELSEIF "$(CPU)" == "ARM64"
+cflags = $(cflags) -D_ARM64_=1 -DWIN64 -D_WIN64  -DWIN32 -D_WIN32
 !ENDIF
 cflags = $(cflags) -D_WIN32_WINNT=$(NMAKE_WINVER) -DWINVER=$(NMAKE_WINVER)
 
@@ -49,6 +54,8 @@ ldebug = /DEBUG /DEBUGTYPE:cv
 CVTRES_CPU=X86
 !ELSEIF "$(CPU)" == "AMD64"
 CVTRES_CPU=X64
+!ELSEIF "$(CPU)" == "ARM64"
+CVTRES_CPU=ARM64
 !ENDIF
 
 !IFNDEF NODEBUG


### PR DESCRIPTION
## Summary
`NT_MAKEFILE`: accept `cpu=ARM64` (or `arm64` / `AARCH64` / `aarch64`),
define `_ARM64_=1` plus the standard `WIN64`/`_WIN64`/`WIN32`/`_WIN32`
macros for ARM64 builds, and set `CVTRES_CPU=ARM64` so resource
compilation mirrors the existing 64-bit target.

No other changes were needed:
- `include/private/gcconfig.h` already maps `_M_ARM64` → `AARCH64`,
  which `cl` auto-defines when targeting ARM64.
- `CMakeLists.txt` has no per-CPU branching for Windows, so the cmake
  path requires no patch.

## Testing
Built and tested natively on Windows on ARM64 (Surface, Win11 26200)
with VS 2022 (cl 19.50.35726, MSVC 14.50, `HostARM64\arm64`
toolchain):

```
nmake -f NT_MAKEFILE cpu=ARM64 nodebug=1
```

Builds the full set of DLLs cleanly with no warnings:
- `gc.dll`, `cord.dll`, `gccpp.dll`, `gctba.dll`

Test executables built and linked OK (CVTRES `/MACHINE:ARM64`
exercised via the `de.exe` resource):
- `gctest.exe`, `cordtest.exe`, `cpptest.exe`, `treetest.exe`, `de.exe`

Test results — all pass (exit 0):
- `gctest.exe` — "Collector appears to work" (target `MSWIN32/AARCH64`,
  GetWriteWatch-based VDB, 12 marker threads, 2393 GC cycles, 1.16 GB
  allocated across the run).
- `cordtest.exe` — `SUCCEEDED`.
- `cpptest.exe` — exit 0.
- `treetest.exe` — `SUCCEEDED`.