### PR TITLE
Use SEH for msvc target when building by Zig

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -458,6 +458,7 @@
     "winpthreads",
     "winscw",
     "WINXP",
+    "Wlanguage",
     "WNDCLASS",
     "wndclass",
     "WORDER",

--- a/build.zig
+++ b/build.zig
@@ -368,11 +368,7 @@ pub fn build(b: *std.Build) void {
     // `-U GC_NO_SIGSETJMP`
     flags.append(b.allocator, "-D HAVE_SYS_TYPES_H") catch unreachable;
 
-    if (t.abi == .msvc) {
-        // To workaround "extension used" error reported
-        // for `__try`/`__finally`.
-        flags.append(b.allocator, "-D NO_SEH_AVAILABLE") catch unreachable;
-    } else {
+    if (t.abi != .msvc) {
         flags.append(b.allocator, "-D HAVE_UNISTD_H") catch unreachable;
     }
 

--- a/mark.c
+++ b/mark.c
@@ -589,6 +589,10 @@ GC_mark_some(ptr_t cold_gc_frame)
      * difficult to avoid otherwise.
      */
 #  ifndef NO_SEH_AVAILABLE
+#    if GC_CLANG_PREREQ(3, 6)
+#      pragma GCC diagnostic push
+#      pragma GCC diagnostic ignored "-Wlanguage-extension-token"
+#    endif
     __try {
       ret_val = GC_mark_some_inner(cold_gc_frame);
     } __except (GetExceptionCode() == EXCEPTION_ACCESS_VIOLATION
@@ -596,6 +600,9 @@ GC_mark_some(ptr_t cold_gc_frame)
                     : EXCEPTION_CONTINUE_SEARCH) {
       goto handle_ex;
     }
+#    if GC_CLANG_PREREQ(3, 6)
+#      pragma GCC diagnostic pop
+#    endif
 #  else
     GC_setup_temporary_fault_handler();
     if (SETJMP(GC_jmp_buf) != 0)

--- a/win32_threads.c
+++ b/win32_threads.c
@@ -1615,6 +1615,10 @@ GC_win32_start_inner(struct GC_stack_base *sb, void *arg)
    */
 #  ifndef NO_SEH_AVAILABLE
   ret = NULL; /*< to avoid "might be uninitialized" compiler warning */
+#    if GC_CLANG_PREREQ(3, 6)
+#      pragma GCC diagnostic push
+#      pragma GCC diagnostic ignored "-Wlanguage-extension-token"
+#    endif
   __try
 #  endif
   {
@@ -1622,6 +1626,9 @@ GC_win32_start_inner(struct GC_stack_base *sb, void *arg)
   }
 #  ifndef NO_SEH_AVAILABLE
   __finally
+#    if GC_CLANG_PREREQ(3, 6)
+#      pragma GCC diagnostic pop
+#    endif
 #  endif
   {
     (void)GC_unregister_my_thread();


### PR DESCRIPTION
Should fix #924 at least for target `x86_64-windiws-msvc`.
