### PR TITLE
Support threads bounds detection by stack walking on Darwin/arm64

### DIFF
--- a/.github/workflows/autotools-build-extra.yml
+++ b/.github/workflows/autotools-build-extra.yml
@@ -22,7 +22,7 @@ jobs:
         - os: ubuntu-latest
           conf_options: --disable-atomic-uncollectible --disable-shared --enable-cplusplus --enable-rwlock
         - os: macos-latest
-          cflags_extra: -D TEST_HANDLE_FORK -D DONT_INCLUDE_LEAK_DETECTOR
+          cflags_extra: -D TEST_HANDLE_FORK -D DARWIN_PARSE_STACK -D DONT_INCLUDE_LEAK_DETECTOR
         - os: ubuntu-24.04-arm
           conf_options: --disable-disclaim
         - os: ubuntu-latest

--- a/configure.ac
+++ b/configure.ac
@@ -482,10 +482,8 @@ if test $compiler_xlc = yes -a "$powerpc_darwin" = true; then
              to walk the frames on the stack.])
 fi
 
-# XLC neither requires nor tolerates the unnecessary assembler goop.
-# Similar for the Sun C compiler.
-AM_CONDITIONAL([ASM_WITH_CPP_UNSUPPORTED],
-    [test $compiler_xlc = yes -o $compiler_suncc = yes])
+# Sun C compiler neither requires nor tolerates the unnecessary assembler goop.
+AM_CONDITIONAL([ASM_WITH_CPP_UNSUPPORTED], [test $compiler_suncc = yes])
 
 # Check for `getcontext` (e.g., uClibc can be configured without it)
 AC_CHECK_FUNC([getcontext], [],

--- a/configure.ac
+++ b/configure.ac
@@ -425,9 +425,6 @@ case "$host" in
     # Turn on the workaround described in `pthread_start.c` file.
     AS_IF([test "$THREADS" = posix], [pthread_start_standalone=yes])
     ;;
-  powerpc-*-darwin*)
-    powerpc_darwin=true
-    ;;
   *-*-solaris*)
     if test "$GCC" != yes; then
       # Solaris SunCC
@@ -466,20 +463,6 @@ if test "$GCC" = yes; then
         [WPEDANTIC="-Wpedantic -Wno-long-long"])
   CFLAGS="-Wall $WEXTRA $WPEDANTIC $CFLAGS"
   CXXFLAGS="-Wall $WEXTRA $WPEDANTIC $CXXFLAGS"
-fi
-
-AC_MSG_CHECKING(for xlc)
-AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
-#   ifndef __xlC__
-#     error
-#   endif
-  ]])], [compiler_xlc=yes], [compiler_xlc=no])
-AC_MSG_RESULT($compiler_xlc)
-if test $compiler_xlc = yes -a "$powerpc_darwin" = true; then
-  # The darwin stack-frame-walking code is completely broken on xlc.
-  AC_DEFINE([DARWIN_DONT_PARSE_STACK], 1,
-            [Define to discover thread stack bounds on Darwin without trying
-             to walk the frames on the stack.])
 fi
 
 # Sun C compiler neither requires nor tolerates the unnecessary assembler goop.

--- a/darwin_stop_world.c
+++ b/darwin_stop_world.c
@@ -47,8 +47,7 @@
 #    endif
 #  endif
 
-#  ifndef DARWIN_DONT_PARSE_STACK
-
+#  ifdef DARWIN_PARSE_STACK
 typedef struct StackFrame {
   word savedSP;
   word savedCR;
@@ -102,8 +101,7 @@ GC_FindTopOfStack(word stack_start)
 #    endif
   return (ptr_t)frame;
 }
-
-#  endif /* !DARWIN_DONT_PARSE_STACK */
+#  endif
 
 /*
  * `GC_query_task_threads` controls whether to obtain the list of the
@@ -148,7 +146,7 @@ GC_stack_range_for(ptr_t *phi, thread_act_t thread, GC_thread p,
                    mach_port_t my_thread, ptr_t *paltstack_lo,
                    ptr_t *paltstack_hi, GC_bool *pfound_me)
 {
-#  ifdef DARWIN_DONT_PARSE_STACK
+#  ifndef DARWIN_PARSE_STACK
   GC_stack_context_t crtn;
 #  endif
   ptr_t lo;
@@ -157,13 +155,13 @@ GC_stack_range_for(ptr_t *phi, thread_act_t thread, GC_thread p,
   if (thread == my_thread) {
     GC_ASSERT(NULL == p || (p->flags & DO_BLOCKING) == 0);
     lo = GC_approx_sp();
-#  ifndef DARWIN_DONT_PARSE_STACK
+#  ifdef DARWIN_PARSE_STACK
     *phi = GC_FindTopOfStack(0);
 #  endif
     *pfound_me = TRUE;
   } else if (p != NULL && (p->flags & DO_BLOCKING) != 0) {
     lo = p->crtn->stack_ptr;
-#  ifndef DARWIN_DONT_PARSE_STACK
+#  ifdef DARWIN_PARSE_STACK
     *phi = p->crtn->topOfStack;
 #  endif
 
@@ -219,7 +217,7 @@ GC_stack_range_for(ptr_t *phi, thread_act_t thread, GC_thread p,
 
 #  if defined(I386)
     lo = (ptr_t)state.THREAD_FLD(esp);
-#    ifndef DARWIN_DONT_PARSE_STACK
+#    ifdef DARWIN_PARSE_STACK
     *phi = GC_FindTopOfStack(state.THREAD_FLD(esp));
 #    endif
     GC_push_one(state.THREAD_FLD(eax));
@@ -232,7 +230,7 @@ GC_stack_range_for(ptr_t *phi, thread_act_t thread, GC_thread p,
 
 #  elif defined(X86_64)
     lo = (ptr_t)state.THREAD_FLD(rsp);
-#    ifndef DARWIN_DONT_PARSE_STACK
+#    ifdef DARWIN_PARSE_STACK
     *phi = GC_FindTopOfStack(state.THREAD_FLD(rsp));
 #    endif
     GC_push_one(state.THREAD_FLD(rax));
@@ -254,7 +252,7 @@ GC_stack_range_for(ptr_t *phi, thread_act_t thread, GC_thread p,
 
 #  elif defined(POWERPC)
     lo = (ptr_t)(state.THREAD_FLD(r1) - PPC_RED_ZONE_SIZE);
-#    ifndef DARWIN_DONT_PARSE_STACK
+#    ifdef DARWIN_PARSE_STACK
     *phi = GC_FindTopOfStack(state.THREAD_FLD(r1));
 #    endif
     GC_push_one(state.THREAD_FLD(r0));
@@ -306,7 +304,7 @@ GC_stack_range_for(ptr_t *phi, thread_act_t thread, GC_thread p,
 
 #  elif defined(AARCH64)
     lo = (ptr_t)state.THREAD_FLD(sp);
-#    ifndef DARWIN_DONT_PARSE_STACK
+#    ifdef DARWIN_PARSE_STACK
     *phi = GC_FindTopOfStack(state.THREAD_FLD(fp));
 #    endif
     {
@@ -325,8 +323,8 @@ GC_stack_range_for(ptr_t *phi, thread_act_t thread, GC_thread p,
 #  endif
   }
 
-#  ifndef DARWIN_DONT_PARSE_STACK
-  /* TODO: Determine `p` and handle `altstack` if `!DARWIN_DONT_PARSE_STACK` */
+#  ifdef DARWIN_PARSE_STACK
+  /* TODO: Determine `p` and handle `altstack`. */
   UNUSED_ARG(paltstack_hi);
 #  else
   /*
@@ -346,7 +344,7 @@ GC_stack_range_for(ptr_t *phi, thread_act_t thread, GC_thread p,
   /* else */ {
     *paltstack_lo = NULL;
   }
-#  if defined(STACKPTR_CORRECTOR_AVAILABLE) && defined(DARWIN_DONT_PARSE_STACK)
+#  if defined(STACKPTR_CORRECTOR_AVAILABLE) && !defined(DARWIN_PARSE_STACK)
   if (GC_sp_corrector != 0)
     GC_sp_corrector((void **)&lo, THREAD_ID_TO_VPTR(p->id));
 #  endif
@@ -370,7 +368,7 @@ GC_push_all_stacks(void)
   GC_ASSERT(I_HOLD_LOCK());
   GC_ASSERT(GC_thr_initialized);
 
-#  ifndef DARWIN_DONT_PARSE_STACK
+#  ifdef DARWIN_PARSE_STACK
   if (GC_query_task_threads) {
     int i;
     kern_return_t kern_result;
@@ -400,7 +398,7 @@ GC_push_all_stacks(void)
     vm_deallocate(my_task, (vm_address_t)act_list,
                   sizeof(thread_t) * listcount);
   } else
-#  endif /* !DARWIN_DONT_PARSE_STACK */
+#  endif
   /* else */ {
     int i;
 

--- a/darwin_stop_world.c
+++ b/darwin_stop_world.c
@@ -69,11 +69,6 @@ GC_FindTopOfStack(unsigned long stack_start)
 #      else
     __asm__ __volatile__("ld %0,0(r1)" : "=r"(frame));
 #      endif
-#    elif defined(ARM32)
-    volatile ptr_t sp_reg;
-
-    __asm__ __volatile__("mov %0, r7\n" : "=r"(sp_reg));
-    frame = (/* no volatile */ StackFrame *)sp_reg;
 #    elif defined(AARCH64)
     volatile ptr_t sp_reg;
 
@@ -297,9 +292,6 @@ GC_stack_range_for(ptr_t *phi, thread_act_t thread, GC_thread p,
 
 #  elif defined(ARM32)
     lo = (ptr_t)state.THREAD_FLD(sp);
-#    ifndef DARWIN_DONT_PARSE_STACK
-    *phi = GC_FindTopOfStack(state.THREAD_FLD(r[7])); /*< `fp` */
-#    endif
     {
       int j;
       for (j = 0; j < 7; j++)

--- a/darwin_stop_world.c
+++ b/darwin_stop_world.c
@@ -49,11 +49,16 @@
 
 #  ifdef DARWIN_PARSE_STACK
 typedef struct StackFrame {
+#    if defined(AARCH64)
+  word prevFP;  /*< previous frame pointer */
+  word savedIP; /*< return address */
+#    else
   word savedSP;
   word savedCR;
   word savedLR;
   /* `word reserved[2];` */
   /* `word savedRTOC;` */
+#    endif
 } StackFrame;
 
 GC_INNER ptr_t
@@ -69,10 +74,7 @@ GC_FindTopOfStack(word stack_start)
     __asm__ __volatile__("ld %0,0(r1)" : "=r"(frame));
 #      endif
 #    elif defined(AARCH64)
-    volatile ptr_t sp_reg;
-
-    __asm__ __volatile__("mov %0, x29\n" : "=r"(sp_reg));
-    frame = (/* no volatile */ StackFrame *)sp_reg;
+    frame = (StackFrame *)__builtin_frame_address(0);
 #    else
     ABORT("GC_FindTopOfStack(0) is not implemented");
 #    endif
@@ -81,6 +83,12 @@ GC_FindTopOfStack(word stack_start)
 #    ifdef DEBUG_THREADS_EXTRA
   GC_log_printf("FindTopOfStack start at sp= %p\n", (void *)frame);
 #    endif
+#    if defined(AARCH64)
+  /* Walk the frame pointer chain. */
+  while (frame->prevFP > ADDR(frame)) {
+    frame = (StackFrame *)MAKE_CPTR(frame->prevFP);
+  }
+#    else
   while (frame->savedSP != 0) { /*< stop if no more stack frames */
     word maskedLR;
 
@@ -96,6 +104,7 @@ GC_FindTopOfStack(word stack_start)
       break;
     }
   }
+#    endif
 #    ifdef DEBUG_THREADS_EXTRA
   GC_log_printf("FindTopOfStack finish at sp= %p\n", (void *)frame);
 #    endif

--- a/darwin_stop_world.c
+++ b/darwin_stop_world.c
@@ -50,15 +50,15 @@
 #  ifndef DARWIN_DONT_PARSE_STACK
 
 typedef struct StackFrame {
-  unsigned long savedSP;
-  unsigned long savedCR;
-  unsigned long savedLR;
-  /* `unsigned long reserved[2];` */
-  /* `unsigned long savedRTOC;` */
+  word savedSP;
+  word savedCR;
+  word savedLR;
+  /* `word reserved[2];` */
+  /* `word savedRTOC;` */
 } StackFrame;
 
 GC_INNER ptr_t
-GC_FindTopOfStack(unsigned long stack_start)
+GC_FindTopOfStack(word stack_start)
 {
   StackFrame *frame = (StackFrame *)MAKE_CPTR(stack_start);
 
@@ -83,7 +83,7 @@ GC_FindTopOfStack(unsigned long stack_start)
   GC_log_printf("FindTopOfStack start at sp= %p\n", (void *)frame);
 #    endif
   while (frame->savedSP != 0) { /*< stop if no more stack frames */
-    unsigned long maskedLR;
+    word maskedLR;
 
     frame = (StackFrame *)MAKE_CPTR(frame->savedSP);
     /*
@@ -91,8 +91,8 @@ GC_FindTopOfStack(unsigned long stack_start)
      * the `savedLR` for the first stack frame in the loop is not set up
      * on purpose, so we should not check it.
      */
-    maskedLR = frame->savedLR & ~0x3UL;
-    if (0 == maskedLR || ~0x3UL == maskedLR) {
+    maskedLR = frame->savedLR & ~(word)0x3;
+    if (0 == maskedLR || ~(word)0x3 == maskedLR) {
       /* The next `savedLR` is bogus, stop. */
       break;
     }

--- a/docs/macros.md
+++ b/docs/macros.md
@@ -512,10 +512,10 @@ are assumed to be zeros regardless of the latter two macros).
 job.  By default this is not supported in order to keep the marker as fast as
 possible.
 
-`DARWIN_DONT_PARSE_STACK` - Causes the Darwin port to discover thread
-stack bounds in the same way as other `pthreads` ports, without trying to
-walk the frames on the stack.  This is recommended only as a fall-back for
-applications that do not support proper stack unwinding.
+`DARWIN_PARSE_STACK` - Causes the Darwin port to discover thread stack bounds
+by walking the stack frames (if supported), instead of using the same approach
+as other `pthreads` ports.  Might be needed to make task-threads-based thread
+registration possible.
 
 `GC_NO_THREADS_DISCOVERY` (Darwin and Win32+DLL only) - Excludes DllMain-based
 (on Windows) and task-threads-based (on Darwin) thread registration support.

--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -1267,7 +1267,7 @@ extern int etext[];
 #    endif
 #    ifdef __xlC__
 /* The stack-frame-walking is broken if the IBM XLC compiler is used. */
-#      define DARWIN_DONT_PARSE_STACK 1
+#      undef DARWIN_PARSE_STACK
 #    endif
 #    define MPROTECT_VDB
 #    if defined(USE_PPC_PREFETCH) && defined(__GNUC__)
@@ -1696,8 +1696,8 @@ extern char *_STACKTOP;
 #    define GETPAGESIZE() 4096
 #  endif
 #  ifdef DARWIN
-#    define DARWIN_DONT_PARSE_STACK 1
 #    define STACKBOTTOM MAKE_CPTR(0xc0000000)
+#    undef DARWIN_PARSE_STACK
 #    define MPROTECT_VDB
 #  endif
 #endif /* I386 */
@@ -2163,8 +2163,8 @@ extern int __data_start[] __attribute__((__weak__));
 #  endif
 #  ifdef DARWIN
 /* OS X, iOS, visionOS */
-#    define DARWIN_DONT_PARSE_STACK 1
 #    define STACKBOTTOM MAKE_CPTR(0x16fdfffff)
+#    undef DARWIN_PARSE_STACK
 #    if (TARGET_OS_IPHONE || TARGET_OS_XR || TARGET_OS_VISION)
 /*
  * `MPROTECT_VDB` causes use of non-public API like `exc_server`, this
@@ -2243,8 +2243,8 @@ extern char **__environ;
 #  endif
 #  ifdef DARWIN
 /* iOS */
-#    define DARWIN_DONT_PARSE_STACK 1
 #    define STACKBOTTOM MAKE_CPTR(0x30000000)
+#    undef DARWIN_PARSE_STACK
 /* `MPROTECT_VDB` causes use of non-public API. */
 #  endif
 #  ifdef NETBSD
@@ -2406,8 +2406,8 @@ EXTERN_C_BEGIN
 /* Nothing specific. */
 #  endif
 #  ifdef DARWIN
-#    define DARWIN_DONT_PARSE_STACK 1
 #    define STACKBOTTOM MAKE_CPTR(0x7fff5fc00000)
+#    undef DARWIN_PARSE_STACK
 #    define MPROTECT_VDB
 #  endif
 #  ifdef FREEBSD
@@ -3402,7 +3402,7 @@ extern ptr_t GC_data_start;
 #ifndef GC_NO_THREADS_DISCOVERY
 #  if defined(DARWIN) && defined(THREADS)
 /* Task-based thread registration requires stack-frame-walking code. */
-#    if defined(DARWIN_DONT_PARSE_STACK)
+#    ifndef DARWIN_PARSE_STACK
 #      define GC_NO_THREADS_DISCOVERY
 #    endif
 #  elif defined(GC_WIN32_THREADS)
@@ -3476,8 +3476,8 @@ extern ptr_t GC_data_start;
 #  define HAVE_CLOCK_GETTIME 1
 #endif
 
-#if defined(GC_PTHREADS) && !defined(E2K) && !defined(IA64)   \
-    && (!defined(DARWIN) || defined(DARWIN_DONT_PARSE_STACK)) \
+#if defined(GC_PTHREADS) && !defined(E2K) && !defined(IA64) \
+    && !(defined(DARWIN) && defined(DARWIN_PARSE_STACK))    \
     && !defined(SN_TARGET_PSP2) && !defined(REDIRECT_MALLOC)
 /*
  * Note: unimplemented in case of redirection of `malloc()` because

--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -1265,6 +1265,10 @@ extern int etext[];
 #      define CPP_WORDSZ 32
 #      define STACKBOTTOM MAKE_CPTR(0xc0000000)
 #    endif
+#    ifdef __xlC__
+/* The stack-frame-walking is broken if the IBM XLC compiler is used. */
+#      define DARWIN_DONT_PARSE_STACK 1
+#    endif
 #    define MPROTECT_VDB
 #    if defined(USE_PPC_PREFETCH) && defined(__GNUC__)
 /* The performance impact of prefetches is untested. */

--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -891,6 +891,10 @@ extern int _end[];
 #  ifndef TARGET_OS_VISION
 #    define TARGET_OS_VISION 0
 #  endif
+#  if !defined(GC_NO_THREADS_DISCOVERY) && defined(THREADS)
+/* FIXME: task-threads-based stop and push does not work correctly. */
+#    define GC_NO_THREADS_DISCOVERY
+#  endif
 #endif /* DARWIN */
 
 #ifdef EMBOX
@@ -2164,7 +2168,6 @@ extern int __data_start[] __attribute__((__weak__));
 #  ifdef DARWIN
 /* OS X, iOS, visionOS */
 #    define STACKBOTTOM MAKE_CPTR(0x16fdfffff)
-#    undef DARWIN_PARSE_STACK
 #    if (TARGET_OS_IPHONE || TARGET_OS_XR || TARGET_OS_VISION)
 /*
  * `MPROTECT_VDB` causes use of non-public API like `exc_server`, this

--- a/include/private/pthread_support.h
+++ b/include/private/pthread_support.h
@@ -585,7 +585,7 @@ GC_INNER_PTHRSTART void GC_thread_exit_proc(void *);
 
 #  ifdef DARWIN
 #    ifndef DARWIN_DONT_PARSE_STACK
-GC_INNER ptr_t GC_FindTopOfStack(unsigned long);
+GC_INNER ptr_t GC_FindTopOfStack(word);
 #    endif
 #    if defined(PARALLEL_MARK) && !defined(GC_NO_THREADS_DISCOVERY)
 /* Note: this is used only by `GC_suspend_thread_list()`. */

--- a/include/private/pthread_support.h
+++ b/include/private/pthread_support.h
@@ -100,7 +100,7 @@ struct GC_StackContext_Rep {
    */
   ptr_t initial_stack_base;
 #    endif
-#  elif defined(DARWIN) && !defined(DARWIN_DONT_PARSE_STACK)
+#  elif defined(DARWIN) && defined(DARWIN_PARSE_STACK)
   /*
    * Result of `GC_FindTopOfStack(0)`; valid only if the thread is blocked;
    * non-`NULL` value means already set.
@@ -584,7 +584,7 @@ GC_INNER_PTHRSTART void GC_thread_exit_proc(void *);
 #  endif /* GC_PTHREADS */
 
 #  ifdef DARWIN
-#    ifndef DARWIN_DONT_PARSE_STACK
+#    ifdef DARWIN_PARSE_STACK
 GC_INNER ptr_t GC_FindTopOfStack(word);
 #    endif
 #    if defined(PARALLEL_MARK) && !defined(GC_NO_THREADS_DISCOVERY)

--- a/include/private/specific.h
+++ b/include/private/specific.h
@@ -128,12 +128,7 @@ GC_INNER int GC_setspecific(tsd *key, void *value);
 GC_INNER void GC_remove_specific_after_fork(tsd *key, pthread_t t);
 
 #ifdef CAN_HANDLE_FORK
-/*
- * Update thread-specific data for the survived thread of the child process.
- * Should be called once after removing thread-specific data for other
- * threads.
- */
-GC_INNER void GC_update_specific_after_fork(tsd *key);
+GC_INNER void GC_update_specific_after_fork_inner(tsd *key);
 #endif
 
 /*

--- a/include/private/thread_local_alloc.h
+++ b/include/private/thread_local_alloc.h
@@ -40,8 +40,7 @@ EXTERN_C_BEGIN
       && !defined(USE_CUSTOM_SPECIFIC)
 #    if defined(GC_WIN32_THREADS)
 #      if defined(CYGWIN) && GC_GNUC_PREREQ(4, 0)
-#        if defined(__clang__)
-/* As of Cygwin clang-3.5.2, thread-local storage is unsupported. */
+#        if defined(__clang__) && !GC_CLANG_PREREQ(8, 0)
 #          define USE_PTHREAD_SPECIFIC
 #        else
 #          define USE_COMPILER_TLS

--- a/include/private/thread_local_alloc.h
+++ b/include/private/thread_local_alloc.h
@@ -160,16 +160,17 @@ EXTERN_C_BEGIN
 typedef pthread_key_t GC_key_t;
 #  elif defined(USE_COMPILER_TLS) || defined(USE_WIN32_COMPILER_TLS)
 #    define GC_getspecific(x) (x)
-#    define GC_setspecific(key, v) ((key) = (v), 0)
-#    define GC_key_create(key, d) 0
-/* Just to clear the pointer to `tlfs`. */
-#    define GC_remove_specific(key) (void)GC_setspecific(key, NULL)
+/*
+ * Do not define `GC_setspecific()` (which is a simple assignment operator)
+ * and `GC_key_create()` (which is no-op).
+ */
+#    define GC_remove_specific(key) (void)((key) = NULL)
 #    define GC_remove_specific_after_fork(key, t) (void)0
 typedef void *GC_key_t;
 #  elif defined(USE_WIN32_SPECIFIC)
 #    define GC_getspecific TlsGetValue
 /* Note: we assume that zero means success, Win32 API does the opposite. */
-#    define GC_setspecific(key, v) !TlsSetValue(key, v)
+#    define GC_setspecific(key, v) (!TlsSetValue(key, v))
 #    ifndef TLS_OUT_OF_INDEXES
 /* This is currently missing in WinCE. */
 #      define TLS_OUT_OF_INDEXES (DWORD)0xFFFFFFFF
@@ -199,13 +200,15 @@ typedef DWORD GC_key_t;
  * Some TLS implementations (e.g., in Cygwin) might be not `fork`-friendly,
  * so we re-assign thread-local value for safety.
  */
-#      define GC_update_specific_after_fork(key, v)    \
-        do {                                           \
-          int res = GC_setspecific(key, v);            \
-                                                       \
-          if (COVERT_DATAFLOW(res) != 0)               \
-            ABORT("GC_setspecific failed (in child)"); \
-        } while (0)
+#      if !defined(USE_COMPILER_TLS) && !defined(USE_WIN32_COMPILER_TLS)
+#        define GC_update_specific_after_fork(key, v)    \
+          do {                                           \
+            if (GC_setspecific(key, v) != 0)             \
+              ABORT("GC_setspecific failed (in child)"); \
+          } while (0)
+#      else
+#        define GC_update_specific_after_fork(key, v) (void)((key) = (v))
+#      endif
 #    endif
 #  endif
 

--- a/include/private/thread_local_alloc.h
+++ b/include/private/thread_local_alloc.h
@@ -195,6 +195,8 @@ typedef DWORD GC_key_t;
 #    ifdef USE_CUSTOM_SPECIFIC
 #      define GC_update_specific_after_fork(key, v) \
         ((void)(v), GC_update_specific_after_fork_inner(key))
+#    elif defined(USE_PTHREAD_SPECIFIC)
+#      define GC_update_specific_after_fork(key, v) ((void)(key), (void)(v))
 #    else
 /*
  * Some TLS implementations (e.g., in Cygwin) might be not `fork`-friendly,

--- a/include/private/thread_local_alloc.h
+++ b/include/private/thread_local_alloc.h
@@ -45,6 +45,8 @@ EXTERN_C_BEGIN
 #        else
 #          define USE_COMPILER_TLS
 #        endif
+#      elif GC_GNUC_PREREQ(4, 9) || GC_CLANG_PREREQ(8, 0)
+#        define USE_COMPILER_TLS
 #      elif defined(__GNUC__) || defined(MSWINCE)
 #        define USE_WIN32_SPECIFIC
 #      else

--- a/include/private/thread_local_alloc.h
+++ b/include/private/thread_local_alloc.h
@@ -184,6 +184,31 @@ typedef DWORD GC_key_t;
 #    error implement me
 #  endif
 
+#  ifdef CAN_HANDLE_FORK
+/*
+ * Update thread-specific data for the survived thread of the child process.
+ * Should be called once after removing thread-specific data for other threads.
+ * Note: it is OK to call `GC_destroy_thread_local()` and `GC_free_internal()`
+ * before this function is called.
+ */
+#    ifdef USE_CUSTOM_SPECIFIC
+#      define GC_update_specific_after_fork(key, v) \
+        ((void)(v), GC_update_specific_after_fork_inner(key))
+#    else
+/*
+ * Some TLS implementations (e.g., in Cygwin) might be not `fork`-friendly,
+ * so we re-assign thread-local value for safety.
+ */
+#      define GC_update_specific_after_fork(key, v)    \
+        do {                                           \
+          int res = GC_setspecific(key, v);            \
+                                                       \
+          if (COVERT_DATAFLOW(res) != 0)               \
+            ABORT("GC_setspecific failed (in child)"); \
+        } while (0)
+#    endif
+#  endif
+
 /*
  * Each thread structure must be initialized.  This call must be made from
  * the new thread.  Caller should hold the allocator lock.

--- a/pthread_support.c
+++ b/pthread_support.c
@@ -1492,22 +1492,7 @@ GC_remove_all_threads_but_me(void)
   store_to_threads_table(THREAD_TABLE_INDEX(me->id), me);
 
 #    ifdef THREAD_LOCAL_ALLOC
-#      ifdef USE_CUSTOM_SPECIFIC
-  GC_update_specific_after_fork(GC_thread_key);
-#      else
-  /*
-   * Some TLS implementations (e.g., in Cygwin) might be not `fork`-friendly,
-   * so we re-assign thread-local pointer to `tlfs` for safety instead of the
-   * assertion check (again, it is OK to call `GC_destroy_thread_local()` and
-   * `GC_free_internal()` before).
-   */
-  {
-    int res = GC_setspecific(GC_thread_key, &me->tlfs);
-
-    if (COVERT_DATAFLOW(res) != 0)
-      ABORT("GC_setspecific failed (in child)");
-  }
-#      endif
+  GC_update_specific_after_fork(GC_thread_key, &me->tlfs);
 #    endif
 #    undef pthread_id
 }

--- a/pthread_support.c
+++ b/pthread_support.c
@@ -2094,7 +2094,7 @@ do_blocking_enter(GC_bool *pTopOfStackUnset, GC_thread me)
 #    else
   crtn->stack_ptr = GC_approx_sp();
 #    endif
-#    if defined(DARWIN) && !defined(DARWIN_DONT_PARSE_STACK)
+#    if defined(DARWIN) && defined(DARWIN_PARSE_STACK)
   if (NULL == crtn->topOfStack) {
     /*
      * `GC_do_blocking_inner` is not called recursively, so `topOfStack`
@@ -2126,7 +2126,7 @@ do_blocking_leave(GC_thread me, GC_bool topOfStackUnset)
     crtn->backing_store_end = NULL;
   }
 #  endif
-#  if defined(DARWIN) && !defined(DARWIN_DONT_PARSE_STACK)
+#  if defined(DARWIN) && defined(DARWIN_PARSE_STACK)
   if (topOfStackUnset) {
     /* Make it unset again. */
     me->crtn->topOfStack = NULL;

--- a/specific.c
+++ b/specific.c
@@ -161,7 +161,7 @@ GC_remove_specific_after_fork(tsd *key, pthread_t t)
 
 #  ifdef CAN_HANDLE_FORK
 GC_INNER void
-GC_update_specific_after_fork(tsd *key)
+GC_update_specific_after_fork_inner(tsd *key)
 {
   unsigned hash_val = TS_HASH(GC_parent_pthread_self);
   tse *entry;

--- a/tests/gctest.c
+++ b/tests/gctest.c
@@ -2468,7 +2468,7 @@ main(void)
     GC_clear_exclusion_table();
 #if defined(THREADS) && !defined(TEST_NO_THREADS_DISCOVERY)              \
     && !defined(GC_NO_THREADS_DISCOVERY) && !defined(THREAD_LOCAL_ALLOC) \
-    && (defined(DARWIN) && !defined(DARWIN_DONT_PARSE_STACK)             \
+    && (defined(DARWIN)                                                  \
         || (defined(GC_WIN32_THREADS) && defined(GC_DLL)                 \
             && !defined(MSWINCE)))
     /* Test with implicit thread registration. */

--- a/thread_local_alloc.c
+++ b/thread_local_alloc.c
@@ -29,13 +29,17 @@ __declspec(thread) GC_ATTR_TLS_FAST
 #  endif
     GC_key_t GC_thread_key;
 
+#  if !defined(USE_COMPILER_TLS) && !defined(USE_WIN32_COMPILER_TLS)
 static GC_bool keys_initialized;
+#  endif
 
 #  ifndef GC_NO_DEINIT
 GC_INNER void
 GC_reset_thread_local_initialization(void)
 {
+#    if !defined(USE_COMPILER_TLS) && !defined(USE_WIN32_COMPILER_TLS)
   keys_initialized = FALSE;
+#    endif
   /* TODO: Dispose resources associated with `GC_thread_key`. */
 }
 #  endif
@@ -113,24 +117,24 @@ reset_thread_key(void *v)
 GC_INNER void
 GC_init_thread_local(GC_tlfs p)
 {
-  int kind, j, res;
+  int kind, j;
 
+#  if !defined(USE_COMPILER_TLS) && !defined(USE_WIN32_COMPILER_TLS)
   GC_ASSERT(I_HOLD_LOCK());
   if (UNLIKELY(!keys_initialized)) {
-#  ifdef USE_CUSTOM_SPECIFIC
+#    ifdef USE_CUSTOM_SPECIFIC
     /* Ensure proper alignment of a "pushed" GC symbol. */
     ASSERT_ALIGNMENT(&GC_thread_key);
-#  endif
-    res = GC_key_create(&GC_thread_key, reset_thread_key);
-    if (COVERT_DATAFLOW(res) != 0) {
+#    endif
+    if (GC_key_create(&GC_thread_key, reset_thread_key) != 0)
       ABORT("Failed to create key for local allocator");
-    }
     keys_initialized = TRUE;
   }
-  res = GC_setspecific(GC_thread_key, p);
-  if (COVERT_DATAFLOW(res) != 0) {
+  if (GC_setspecific(GC_thread_key, p) != 0)
     ABORT("Failed to set thread specific allocation pointers");
-  }
+#  else
+  GC_thread_key = p;
+#  endif
   for (j = 0; j < GC_TINY_FREELISTS; ++j) {
     for (kind = 0; kind < THREAD_FREELISTS_KINDS; ++kind) {
       p->_freelists[kind][j] = NUMERIC_TO_VPTR(1);
@@ -173,7 +177,12 @@ GC_destroy_thread_local(GC_tlfs p)
 STATIC void *
 GC_get_tlfs(void)
 {
-#  if !defined(USE_PTHREAD_SPECIFIC) && !defined(USE_WIN32_SPECIFIC)
+#  if defined(USE_PTHREAD_SPECIFIC) || defined(USE_WIN32_SPECIFIC)
+  if (UNLIKELY(!keys_initialized))
+    return NULL;
+
+  return GC_getspecific(GC_thread_key);
+#  else
   GC_key_t k = GC_thread_key;
 
   if (UNLIKELY(0 == k)) {
@@ -184,11 +193,6 @@ GC_get_tlfs(void)
     return NULL;
   }
   return GC_getspecific(k);
-#  else
-  if (UNLIKELY(!keys_initialized))
-    return NULL;
-
-  return GC_getspecific(GC_thread_key);
 #  endif
 }
 

--- a/thread_local_alloc.c
+++ b/thread_local_alloc.c
@@ -44,6 +44,30 @@ GC_reset_thread_local_initialization(void)
 }
 #  endif
 
+/* Initialize all the free lists of a thread-local storage structure. */
+static void
+init_freelists(GC_tlfs p)
+{
+  int kind, j;
+
+  for (j = 0; j < GC_TINY_FREELISTS; ++j) {
+    for (kind = 0; kind < THREAD_FREELISTS_KINDS; ++kind) {
+      p->_freelists[kind][j] = NUMERIC_TO_VPTR(1);
+    }
+#  ifdef GC_GCJ_SUPPORT
+    p->gcj_freelists[j] = NUMERIC_TO_VPTR(1);
+#  endif
+  }
+  /*
+   * The zero-sized free list is handled like the regular free list, to
+   * ensure that the explicit deallocation works.  However, an allocation
+   * of a `gcj` object with the zero size is always an error.
+   */
+#  ifdef GC_GCJ_SUPPORT
+  p->gcj_freelists[0] = MAKE_CPTR(ERROR_FL);
+#  endif
+}
+
 /*
  * Return a single nonempty free list `fl` to the global one pointed to
  * by `gfl`.
@@ -117,8 +141,6 @@ reset_thread_key(void *v)
 GC_INNER void
 GC_init_thread_local(GC_tlfs p)
 {
-  int kind, j;
-
 #  if !defined(USE_COMPILER_TLS) && !defined(USE_WIN32_COMPILER_TLS)
   GC_ASSERT(I_HOLD_LOCK());
   if (UNLIKELY(!keys_initialized)) {
@@ -130,26 +152,13 @@ GC_init_thread_local(GC_tlfs p)
       ABORT("Failed to create key for local allocator");
     keys_initialized = TRUE;
   }
+#  endif
+  init_freelists(p);
+#  if !defined(USE_COMPILER_TLS) && !defined(USE_WIN32_COMPILER_TLS)
   if (GC_setspecific(GC_thread_key, p) != 0)
     ABORT("Failed to set thread specific allocation pointers");
 #  else
   GC_thread_key = p;
-#  endif
-  for (j = 0; j < GC_TINY_FREELISTS; ++j) {
-    for (kind = 0; kind < THREAD_FREELISTS_KINDS; ++kind) {
-      p->_freelists[kind][j] = NUMERIC_TO_VPTR(1);
-    }
-#  ifdef GC_GCJ_SUPPORT
-    p->gcj_freelists[j] = NUMERIC_TO_VPTR(1);
-#  endif
-  }
-  /*
-   * The zero-sized free list is handled like the regular free list, to
-   * ensure that the explicit deallocation works.  However, an allocation
-   * of a `gcj` object with the zero size is always an error.
-   */
-#  ifdef GC_GCJ_SUPPORT
-  p->gcj_freelists[0] = MAKE_CPTR(ERROR_FL);
 #  endif
 }
 


### PR DESCRIPTION
Includes:
- refactoring of thread_local_alloc
- replacement of DARWIN_DONT_PARSE_STACK to DARWIN_PARSE_STACK
- refactoring of stack-walk code on Darwin
- enable compiler TLS for gcc/clang