### PR TITLE
Expose nanosecond fraction of GC total time measurement

### DIFF
--- a/alloc.c
+++ b/alloc.c
@@ -73,6 +73,12 @@ GC_get_full_gc_total_time(void)
   return GC_full_gc_total_time;
 }
 
+GC_API unsigned int GC_CALL
+GC_get_full_gc_total_time_ns_frac(void)
+{
+  return GC_full_gc_total_ns_frac;
+}
+
 GC_API unsigned long GC_CALL
 GC_get_stopped_mark_total_time(void)
 {

--- a/include/gc/gc.h
+++ b/include/gc/gc.h
@@ -517,6 +517,13 @@ GC_API void GC_CALL GC_start_performance_measurement(void);
 GC_API unsigned long GC_CALL GC_get_full_gc_total_time(void);
 
 /**
+ * Get the fractional nanosecond part of `GC_get_full_gc_total_time`,
+ * ranging from 0 to 1,000,000.  Defined only if the library has been
+ * compiled without `NO_CLOCK` macro defined.
+ */
+GC_API unsigned int GC_CALL GC_get_full_gc_total_time_ns_frac(void);
+
+/**
  * Same as `GC_get_full_gc_total_time` but takes into account all mark
  * phases with the world stopped and nothing else.
  */


### PR DESCRIPTION
Currently GC collection time measurements are only exposed with millisecond precision. This adds an API call to retrieve the nanosecond part.

In my usecase GC collection times are often on the order of a few milliseconds, so being limited to millisecond precision is too coarse.