### PR TITLE
Fix negative GC_DS_PER_OBJECT descriptors can lead to data misinterpreted as type descriptors

### DIFF
--- a/.github/workflows/autotools-build-extra.yml
+++ b/.github/workflows/autotools-build-extra.yml
@@ -383,6 +383,11 @@ jobs:
           - os: ubuntu-latest
             conf_options: --enable-gc-assertions
             cflags_extra: >-
+              -D _FORTIFY_SOURCE=2 -D GC_GCJ_MARK_DESCR_OFFSET=32 -m32
+            install_multilib: true
+          - os: ubuntu-latest
+            conf_options: --enable-gc-assertions
+            cflags_extra: >-
               -D MARK_BIT_PER_OBJ -D USE_CUSTOM_SPECIFIC
               -D _FORTIFY_SOURCE=2 -m32
             install_multilib: true
@@ -432,12 +437,6 @@ jobs:
             #     -D NO_INCREMENTAL -D TEST_FORK_WITHOUT_ATFORK
             #     -fno-omit-frame-pointer -fsanitize=thread
             #   fetch_libatomic_ops: true
-            # FIXME: Assertion violation about length-based descriptor
-            # - os: ubuntu-latest
-            #   conf_options: --enable-gc-assertions
-            #   cflags_extra: >-
-            #     -D GC_GCJ_MARK_DESCR_OFFSET=32 -D _FORTIFY_SOURCE=2 -m32
-            #   install_multilib: true
             # FIXME: Signals delivery fails constantly.
             # - os: ubuntu-latest
             #   conf_options: --disable-shared

--- a/alloc.c
+++ b/alloc.c
@@ -538,6 +538,7 @@ GC_notify_full_gc(void)
 
 STATIC GC_bool GC_stopped_mark(GC_stop_func stop_func);
 STATIC void GC_finish_collection(void);
+static void set_all_fl_marks(GC_bool indir_ds_only);
 
 /*
  * Initiate a garbage collection if appropriate.  Choose judiciously
@@ -570,6 +571,9 @@ GC_maybe_gc(void)
     GC_promote_black_lists();
     (void)GC_reclaim_all((GC_stop_func)0, TRUE);
     GC_clear_marks();
+    /* See the comment in `GC_try_to_collect_inner()`. */
+    if (!GC_incremental)
+      set_all_fl_marks(TRUE);
     EXIT_GC();
     GC_n_partial_gcs = 0;
     GC_is_full_gc = TRUE;
@@ -674,6 +678,17 @@ GC_try_to_collect_inner(GC_stop_func stop_func)
   }
   GC_invalidate_mark_state(); /*< flush mark stack */
   GC_clear_marks();
+  /*
+   * Pre-mark free-list objects, so that a false reference to a free-list
+   * entry cannot cause its first "pointer-sized" word (`next` link) to
+   * be misread as a type descriptor by a negative `GC_DS_PER_OBJECT` kind.
+   * The mark bit is checked before inspecting any descriptor, thus
+   * a pre-marked free object is skipped without ever dereferencing its link.
+   * Such descriptors are incompatible with the incremental mode, as of now.
+   */
+  if (!GC_incremental)
+    set_all_fl_marks(TRUE);
+
   SAVE_CALLERS_TO_LAST_STACK();
   GC_is_full_gc = TRUE;
   EXIT_GC();
@@ -1229,20 +1244,28 @@ GC_clear_fl_marks(ptr_t q)
   }
 }
 
-/* Mark all objects on the free lists for every object kind. */
+/*
+ * Mark all objects on the free lists for certain or all object kinds.
+ * If `indir_ds_only`, then only objects with the negative descriptor are
+ * processed.
+ */
 static void
-set_all_fl_marks(void)
+set_all_fl_marks(GC_bool indir_ds_only)
 {
   unsigned kind;
 
   for (kind = 0; kind < GC_n_kinds; kind++) {
-    size_t lg;
+    if (!indir_ds_only
+        || UNLIKELY(
+            IS_INDIR_PER_OBJ_DESCR(GC_obj_kinds[kind].ok_descriptor))) {
+      size_t lg;
 
-    for (lg = 1; lg <= MAXOBJGRANULES; lg++) {
-      ptr_t q = (ptr_t)GC_obj_kinds[kind].ok_freelist[lg];
+      for (lg = 1; lg <= MAXOBJGRANULES; lg++) {
+        ptr_t q = (ptr_t)GC_obj_kinds[kind].ok_freelist[lg];
 
-      if (q != NULL)
-        GC_set_fl_marks(q);
+        if (q != NULL)
+          GC_set_fl_marks(q);
+      }
     }
   }
 }
@@ -1331,7 +1354,7 @@ GC_finish_collection(void)
 #endif
   COND_DUMP;
   if (GC_find_leak_inner) {
-    set_all_fl_marks();
+    set_all_fl_marks(FALSE);
     /* This just checks; it does not really reclaim anything. */
     GC_start_reclaim(TRUE);
   }

--- a/include/private/gc_priv.h
+++ b/include/private/gc_priv.h
@@ -3235,6 +3235,17 @@ void GC_check_fl_marks(void **);
 #endif
 
 /*
+ * Is this a negative descriptor with an offset larger than a pointer size?
+ * (A negative `GC_DS_PER_OBJECT` descriptor is the only kind that has
+ * a negative numeric value, so a single signed comparison suffices to
+ * identify those with an offset larger than a pointer size.)
+ */
+#define IS_INDIR_PER_OBJ_DESCR(d)                             \
+  (((d) & (SIGNB | GC_DS_TAGS)) == (SIGNB | GC_DS_PER_OBJECT) \
+   && (d) <= ~(word)sizeof(ptr_t)                             \
+                 - (GC_INDIR_PER_OBJ_BIAS - GC_DS_PER_OBJECT))
+
+/*
  * Add [`b`,`e`) to the root set.  Adding the same interval a second
  * time is a moderately fast no-op, and hence benign.  We do not handle
  * different but overlapping intervals efficiently.  (But we do handle

--- a/include/private/gcconfig.h
+++ b/include/private/gcconfig.h
@@ -2956,8 +2956,15 @@ EXTERN_C_BEGIN
 #  undef DYNAMIC_LOADING
 #endif
 
-#if defined(SMALL_CONFIG) && !defined(GC_DISABLE_INCREMENTAL)
-/* Presumably not worth the space it takes. */
+#if (defined(KEEP_BACK_PTRS) || defined(SMALL_CONFIG)) \
+    && !defined(GC_DISABLE_INCREMENTAL)
+/*
+ * If we are keeping back pointers, the collector itself dirties all pages
+ * on which objects have been marked, making the incremental collection
+ * pointless.
+ * For small heap sizes: the incremental collection presumably is not worth
+ * the space it takes.
+ */
 #  define GC_DISABLE_INCREMENTAL
 #endif
 

--- a/misc.c
+++ b/misc.c
@@ -973,6 +973,24 @@ GC_get_supported_vdbs(void)
 }
 
 #ifndef GC_DISABLE_INCREMENTAL
+/*
+ * Check if any registered object kind has a negative `GC_DS_PER_OBJECT`
+ * descriptor (with the offset large enough that a free-list `next` link is
+ * likely to be misinterpreted as a type descriptor).  Such descriptors are
+ * incompatible with the incremental mode.
+ */
+static GC_bool
+has_obj_kinds_with_indir_descr(void)
+{
+  unsigned kind;
+
+  for (kind = 0; kind < GC_n_kinds; kind++) {
+    if (UNLIKELY(IS_INDIR_PER_OBJ_DESCR(GC_obj_kinds[kind].ok_descriptor)))
+      return TRUE;
+  }
+  return FALSE;
+}
+
 static void
 set_incremental_mode_on(void)
 {
@@ -1449,7 +1467,9 @@ GC_init(void)
     GC_init_linux_data_start();
 #endif
 #ifndef GC_DISABLE_INCREMENTAL
-  if (GC_incremental || GETENV("GC_ENABLE_INCREMENTAL") != NULL) {
+  if (GC_incremental
+      || (GETENV("GC_ENABLE_INCREMENTAL") != NULL
+          && !has_obj_kinds_with_indir_descr())) {
     set_incremental_mode_on();
     GC_ASSERT(0 == GC_bytes_allocd);
   }
@@ -1579,14 +1599,14 @@ GC_init(void)
 GC_API void GC_CALL
 GC_enable_incremental(void)
 {
-#if !defined(GC_DISABLE_INCREMENTAL) && !defined(KEEP_BACK_PTRS)
-  /*
-   * If we are keeping back pointers, the collector itself dirties all pages
-   * on which objects have been marked, making the incremental collection
-   * pointless.
-   */
+#ifndef GC_DISABLE_INCREMENTAL
   if (!GC_find_leak_inner && NULL == GETENV("GC_DISABLE_INCREMENTAL")) {
     LOCK();
+    if (has_obj_kinds_with_indir_descr()) {
+      UNLOCK();
+      GC_init();
+      return;
+    }
     if (!GC_incremental) {
       GC_setpagesize();
       /* TODO: Should we skip enabling incremental if win32s? */
@@ -2442,6 +2462,17 @@ GC_new_kind_inner(void **fl, GC_word descr, int adjust, int clear)
   GC_ASSERT(1 == clear || (0 == descr && !adjust && !clear));
   if (result < MAXOBJKINDS) {
     GC_ASSERT(result > 0);
+#ifndef GC_DISABLE_INCREMENTAL
+    /*
+     * Negative `GC_DS_PER_OBJECT` descriptors (with offsets larger than
+     * the size of a pointer) are incompatible with the incremental mode,
+     * because free-list `next` links can be misread as type descriptors
+     * during rescan of dirty pages.
+     * TODO: Turn off the incremental mode instead of abort.
+     */
+    if (GC_incremental && UNLIKELY(IS_INDIR_PER_OBJ_DESCR(descr)))
+      ABORT("Incremental GC is incompatible with negative descriptors");
+#endif
     GC_n_kinds++;
     GC_obj_kinds[result].ok_freelist = fl;
     GC_obj_kinds[result].ok_reclaim_list = 0;

--- a/tests/gctest.c
+++ b/tests/gctest.c
@@ -2165,6 +2165,8 @@ enable_incremental_mode(void)
     && !defined(GC_DISABLE_INCREMENTAL)
 #  if !defined(MAKE_BACK_GRAPH) && !defined(NO_INCREMENTAL)   \
       && !(defined(USE_PROC_FOR_LIBRARIES) && defined(LINUX)) \
+      && !(defined(GC_GCJ_SUPPORT)                            \
+           && GC_GCJ_MARK_DESCR_OFFSET > GC_SIZEOF_PTR)       \
       && !defined(REDIRECT_MALLOC)
   {
     unsigned vdbs = (unsigned)COVERT_DATAFLOW(GC_get_supported_vdbs());


### PR DESCRIPTION
.